### PR TITLE
Make sdk-toolchain real

### DIFF
--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -186,6 +186,15 @@ android_sdk(
     zipalign = ":zipalign",
 )
 
+# Exists for backwards compatibility with MODULE.bazel register_toolchains copied from rules_android
+toolchain(
+    name = "sdk-toolchain",
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//:incompatible"],
+    toolchain = ":fail",
+    toolchain_type = ":sdk_toolchain_type",
+)
+
 filegroup(
     name = "files",
     srcs = [

--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -186,31 +186,6 @@ android_sdk(
     zipalign = ":zipalign",
 )
 
-toolchain(
-    name = "sdk-toolchain",
-    tags = ["manual"],
-    target_compatible_with = ["@platforms//:incompatible"],
-    toolchain = ":fail",
-    toolchain_type = ":sdk_toolchain_type",
-)
-
-android_toolchain(
-    name = "android_default",
-    aapt2 = ":aapt2",
-    adb = ":adb",
-    android_archive_jar_optimization_inputs_validator = ":fail",
-    android_archive_packages_validator = ":fail",
-    apk_to_bundle_tool = ":fail",
-    centralize_r_class_tool = ":fail",
-    desugar_globals_jar = ":fail",
-    merge_baseline_profiles_tool = ":fail",
-    object_method_rewriter = ":fail",
-    profgen = ":fail",
-    proto_map_generator = ":fail",
-    tags = ["manual"],
-    translation_merger = ":fail",
-)
-
 filegroup(
     name = "files",
     srcs = [

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -698,6 +698,13 @@ def _platform_aliases(sdk):
     build_tools_directory = sdk["build_tools_directory"]
     blocks = [
         _platform_select_alias(
+            "sdk-toolchain",
+            platforms,
+            ":sdk_linux_toolchain",
+            ":sdk_darwin_toolchain",
+            ":sdk_windows_toolchain",
+        ),
+        _platform_select_alias(
             "aapt",
             platforms,
             _tool_alias_label("linux", build_tools_directory, "aapt"),

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -698,13 +698,6 @@ def _platform_aliases(sdk):
     build_tools_directory = sdk["build_tools_directory"]
     blocks = [
         _platform_select_alias(
-            "sdk-toolchain",
-            platforms,
-            ":sdk_linux_toolchain",
-            ":sdk_darwin_toolchain",
-            ":sdk_windows_toolchain",
-        ),
-        _platform_select_alias(
             "aapt",
             platforms,
             _tool_alias_label("linux", build_tools_directory, "aapt"),

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -47,5 +47,6 @@ build_test(
         "@androidsdk//:emulator_x86_bios",
         "@androidsdk//:mksd",
         "@androidsdk//:qemu2_x86",
+        "@androidsdk//:sdk-toolchain",
     ],
 )


### PR DESCRIPTION
This doesn't matter for this toolchain but is nicer if it analyzes for
conversions from rules_android which recommends you register this
directly
