### PR TITLE
Add adb override instructions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,10 @@ common --android_platforms=@rules_android//:x86_64
 # Help CI OOMs on Windows
 build:windows --nodesugar_for_android
 
+mobile-install:linux --adb=external/+android+androidsdk/platform-tools/linux/adb
+mobile-install:macos --adb=external/+android+androidsdk/platform-tools/darwin/adb
+mobile-install:windows --adb=external/+android+androidsdk/platform-tools/windows/adb.exe
+
 common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=35
 common --repo_env=ACCEPTED_ANDROID_NDK_LICENSE_VERSION=r25c
 

--- a/README.md
+++ b/README.md
@@ -116,3 +116,16 @@ android.ndk(
     strip_prefix = "android-ndk-r27d",
 )
 ```
+
+## `adb` setup
+
+If you want to use the `adb` CLI that comes with the vendored SDK
+instead of one installed on the host system, you must tell bazel where
+to find it by adding this to your `.bazelrc`:
+
+```
+common --enable_platform_specific_config
+mobile-install:linux --adb=external/+android+androidsdk/platform-tools/linux/adb
+mobile-install:macos --adb=external/+android+androidsdk/platform-tools/darwin/adb
+mobile-install:windows --adb=external/+android+androidsdk/platform-tools/windows/adb.exe
+```

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -726,6 +726,13 @@ def _platform_aliases(sdk):
             _adb_alias_label("windows"),
         ),
         _platform_select_alias(
+            "platform-tools/adb",
+            platforms,
+            _adb_alias_label("linux"),
+            _adb_alias_label("darwin"),
+            _adb_alias_label("windows"),
+        ),
+        _platform_select_alias(
             "apksigner",
             platforms,
             ":apksigner_linux",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -47,6 +47,7 @@ build_test(
         "@androidsdk//:emulator_x86_bios",
         "@androidsdk//:mksd",
         "@androidsdk//:qemu2_x86",
+        "@androidsdk//:platform-tools/adb",
         "@androidsdk//:sdk-toolchain",
     ],
 )


### PR DESCRIPTION
Currently the adb discovery logic in rules_android is:

- `--adb`
- `$ANDROID_ADB`
- `which adb`
- `/usr/bin/adb`

Typically I think people who are setting `ANDROID_HOME` just set `PATH`
to include `$ANDROID_HOME/platform-tools` which is how bazel finds it.
That approach is still fine as long as you're ok using an `adb` from a
different SDK than from the one that is vendored here.
