### PR TITLE
Make version and build_tools_version mandatory

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -13,7 +13,10 @@ Setup docs: https://github.com/keith/hermetic_android_toolchains#usage
 bazel_dep(name = "hermetic_android_toolchains", version = "$new_version")
 
 android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android")
-android.sdk(version = "35")
+android.sdk(
+    version = "35",
+    build_tools_version = "35.0.0",
+)
 android.ndk(version = "r25c")
 use_repo(android, "androidsdk", "androidndk")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,10 @@ rules_java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolc
 use_repo(rules_java_toolchains, "remote_java_tools")
 
 android = use_extension("//:extensions.bzl", "android", dev_dependency = True)
-android.sdk(version = "35")
+android.sdk(
+    version = "35",
+    build_tools_version = "35.0.0",
+)
 android.ndk(version = "r25c")
 use_repo(android, "androidndk", "androidsdk")
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ bazel_dep(name = "hermetic_android_toolchains", version = "0.0.0")
 bazel_dep(name = "rules_android", version = "0.7.3")
 
 android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android")
-android.sdk(version = "35")
+android.sdk(
+    version = "35",
+    build_tools_version = "35.0.0",
+)
 android.ndk(version = "r25c")
 use_repo(android, "androidsdk", "androidndk")
 
@@ -34,8 +37,9 @@ common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=35
 common --repo_env=ACCEPTED_ANDROID_NDK_LICENSE_VERSION=r25c
 ```
 
-Use `android.ndk(api_level = ...)` to specify a different API level for
-the NDK.
+SDK, build-tools, and NDK versions are explicit. Use
+`android.ndk(version = "r25c", api_level = ...)` to specify a different
+API level for the NDK.
 
 ## Specifying versions
 

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,9 +1,7 @@
 """Module extension for Android SDK and NDK repositories."""
 
 load("//ndk:repositories.bzl", "ANDROID_NDK_LICENSE_ENV", "NDK_TAG", "hermetic_android_ndk_repository")
-load("//ndk:versions.bzl", "DEFAULT_NDK_VERSION")
 load("//sdk:repositories.bzl", "ANDROID_SDK_LICENSE_ENV", "SDK_TAG", "hermetic_android_sdk_repository")
-load("//sdk:versions.bzl", "DEFAULT_SDK_VERSION")
 
 def _single_root_tag(module_ctx, tag_name):
     root_tags = []
@@ -19,7 +17,11 @@ def _single_root_tag(module_ctx, tag_name):
 
 def _sdk_kwargs(tag):
     if not tag:
-        return {"version": DEFAULT_SDK_VERSION}
+        fail("Expected a root android.sdk(...) tag with version and build_tools_version.")
+    if not tag.version:
+        fail("android.sdk(...) requires version.")
+    if not tag.build_tools_version:
+        fail("android.sdk(...) requires build_tools_version.")
 
     return {
         "api_level": tag.api_level,
@@ -40,19 +42,21 @@ def _sdk_kwargs(tag):
         "system_image_sha256s": tag.system_image_sha256s,
         "system_image_strip_prefixes": tag.system_image_strip_prefixes,
         "system_image_urls": tag.system_image_urls,
-        "version": tag.version or DEFAULT_SDK_VERSION,
+        "version": tag.version,
     }
 
 def _ndk_kwargs(tag):
     if not tag:
-        return {"version": DEFAULT_NDK_VERSION}
+        fail("Expected a root android.ndk(...) tag with version.")
+    if not tag.version:
+        fail("android.ndk(...) requires version.")
 
     return {
         "api_level": tag.api_level,
         "sha256s": tag.sha256s,
         "strip_prefix": tag.strip_prefix,
         "urls": tag.urls,
-        "version": tag.version or DEFAULT_NDK_VERSION,
+        "version": tag.version,
     }
 
 def _android_impl(module_ctx):

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -1,13 +1,13 @@
 """Repository rule for downloading a hermetic Android NDK."""
 
-load("//ndk:versions.bzl", "DEFAULT_API_LEVEL", "DEFAULT_NDK_VERSION", "NDK_VERSIONS")
+load("//ndk:versions.bzl", "DEFAULT_API_LEVEL", "NDK_VERSIONS")
 
 ANDROID_NDK_LICENSE_ENV = "ACCEPTED_ANDROID_NDK_LICENSE_VERSION"
 
 NDK_TAG = tag_class(attrs = {
     "version": attr.string(
-        default = DEFAULT_NDK_VERSION,
-        doc = "Known NDK version. Defaults to {}.".format(DEFAULT_NDK_VERSION),
+        doc = "Known NDK version.",
+        mandatory = True,
     ),
     "api_level": attr.int(
         doc = "Minimum Android API level for the NDK C/C++ toolchains. Defaults to {}.".format(DEFAULT_API_LEVEL),
@@ -194,6 +194,9 @@ def _generate_platform_build_files(rctx, ndk):
         )
 
 def _hermetic_android_ndk_repository_impl(rctx):
+    if not rctx.attr.version:
+        fail("hermetic_android_ndk_repository requires version.")
+
     _require_license(rctx)
     ndk = _resolve_ndk(rctx)
     _download_ndk(rctx, ndk)

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -1,18 +1,20 @@
 """Repository rule for downloading a hermetic Android SDK."""
 
-load("//sdk:versions.bzl", "DEFAULT_SDK_VERSION", "SDK_VERSIONS")
+load("//sdk:versions.bzl", "SDK_VERSIONS")
 
 ANDROID_SDK_LICENSE_ENV = "ACCEPTED_ANDROID_SDK_LICENSE_VERSION"
 
 SDK_TAG = tag_class(attrs = {
     "version": attr.string(
-        doc = "Known SDK bundle version or custom SDK version identifier. Defaults to {} unless custom archives are provided.".format(DEFAULT_SDK_VERSION),
+        doc = "Known SDK bundle version or custom SDK version identifier.",
+        mandatory = True,
     ),
     "api_level": attr.string(
         doc = "Android API level to expose. Overrides the known bundle default.",
     ),
     "build_tools_version": attr.string(
-        doc = "Android build-tools version. Overrides the known bundle default.",
+        doc = "Android build-tools version.",
+        mandatory = True,
     ),
     "build_tools_directory": attr.string(
         doc = "Directory name under build-tools/. Defaults to build_tools_version.",
@@ -236,7 +238,7 @@ def _common_platforms(*platform_groups):
 def _resolve_known_sdk(rctx, data, known):
     components = data["components"]
     api_level = rctx.attr.api_level or known["api_level"]
-    build_tools_version = rctx.attr.build_tools_version or known["build_tools_version"]
+    build_tools_version = rctx.attr.build_tools_version
     emulator_version = rctx.attr.emulator_version or known["emulator_version"]
 
     if build_tools_version not in components["build_tools"]:
@@ -850,6 +852,11 @@ def _write_runner_scripts(rctx, sdk):
             )
 
 def _hermetic_android_sdk_repository_impl(rctx):
+    if not rctx.attr.version:
+        fail("hermetic_android_sdk_repository requires version.")
+    if not rctx.attr.build_tools_version:
+        fail("hermetic_android_sdk_repository requires build_tools_version.")
+
     _require_license(rctx)
     sdk = _resolve_sdk(rctx)
     _download_sdk(rctx, sdk)
@@ -883,7 +890,7 @@ hermetic_android_sdk_repository = repository_rule(
         "build_tools_sha256s": attr.string_dict(),
         "build_tools_strip_prefixes": attr.string_dict(),
         "build_tools_urls": attr.string_dict(),
-        "build_tools_version": attr.string(),
+        "build_tools_version": attr.string(mandatory = True),
         "emulator_sha256s": attr.string_dict(),
         "emulator_strip_prefixes": attr.string_dict(),
         "emulator_urls": attr.string_dict(),


### PR DESCRIPTION
Would be curious to know what others thing here but the build tools version and version both impact builds. It's probably best to not default these and instead ask repo maintainers to explicitly decide what to use up front so that we aren't unintentionally causing regressions in builds by assumed defaults.