### PR TITLE
Create one repo per platform

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,9 +10,9 @@ common --android_platforms=@rules_android//:x86_64
 # Help CI OOMs on Windows
 build:windows --nodesugar_for_android
 
-mobile-install:linux --adb=external/+android+androidsdk/platform-tools/linux/adb
-mobile-install:macos --adb=external/+android+androidsdk/platform-tools/darwin/adb
-mobile-install:windows --adb=external/+android+androidsdk/platform-tools/windows/adb.exe
+mobile-install:linux --adb=external/+android+androidsdk_linux/platform-tools/linux/adb
+mobile-install:macos --adb=external/+android+androidsdk_darwin/platform-tools/darwin/adb
+mobile-install:windows --adb=external/+android+androidsdk_windows/platform-tools/windows/adb.exe
 
 common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=35
 common --repo_env=ACCEPTED_ANDROID_NDK_LICENSE_VERSION=r25c

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,8 +20,8 @@ use_repo(rules_java_toolchains, "remote_java_tools")
 
 android = use_extension("//:extensions.bzl", "android", dev_dependency = True)
 android.sdk(
-    version = "35",
     build_tools_version = "35.0.0",
+    version = "35",
 )
 android.ndk(version = "r25c")
 use_repo(android, "androidndk", "androidsdk")

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ to find it by adding this to your `.bazelrc`:
 
 ```
 common --enable_platform_specific_config
-mobile-install:linux --adb=external/+android+androidsdk/platform-tools/linux/adb
-mobile-install:macos --adb=external/+android+androidsdk/platform-tools/darwin/adb
-mobile-install:windows --adb=external/+android+androidsdk/platform-tools/windows/adb.exe
+mobile-install:linux --adb=external/+android+androidsdk_linux/platform-tools/linux/adb
+mobile-install:macos --adb=external/+android+androidsdk_darwin/platform-tools/darwin/adb
+mobile-install:windows --adb=external/+android+androidsdk_windows/platform-tools/windows/adb.exe
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ bazel_dep(name = "rules_android", version = "0.7.3")
 
 android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android")
 android.sdk(
-    version = "35",
     build_tools_version = "35.0.0",
+    version = "35",
 )
 android.ndk(version = "r25c")
 use_repo(android, "androidsdk", "androidndk")

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,7 +1,21 @@
 """Module extension for Android SDK and NDK repositories."""
 
-load("//ndk:repositories.bzl", "ANDROID_NDK_LICENSE_ENV", "NDK_TAG", "hermetic_android_ndk_repository")
-load("//sdk:repositories.bzl", "ANDROID_SDK_LICENSE_ENV", "SDK_TAG", "hermetic_android_sdk_repository")
+load(
+    "//ndk:repositories.bzl",
+    "ANDROID_NDK_LICENSE_ENV",
+    "NDK_PLATFORMS",
+    "NDK_TAG",
+    "hermetic_android_ndk_platform_repository",
+    "hermetic_android_ndk_repository",
+)
+load(
+    "//sdk:repositories.bzl",
+    "ANDROID_SDK_LICENSE_ENV",
+    "SDK_PLATFORMS",
+    "SDK_TAG",
+    "hermetic_android_sdk_platform_repository",
+    "hermetic_android_sdk_repository",
+)
 
 def _single_root_tag(module_ctx, tag_name):
     root_tags = []
@@ -56,8 +70,35 @@ def _android_impl(module_ctx):
     sdk = _sdk_kwargs(_single_root_tag(module_ctx, "sdk"))
     ndk = _ndk_kwargs(_single_root_tag(module_ctx, "ndk"))
 
-    hermetic_android_sdk_repository(name = "androidsdk", **sdk)
-    hermetic_android_ndk_repository(name = "androidndk", **ndk)
+    sdk_platform_repositories = {}
+    for platform in SDK_PLATFORMS:
+        name = "androidsdk_{}".format(platform)
+        hermetic_android_sdk_platform_repository(
+            name = name,
+            platform = platform,
+            **sdk
+        )
+        sdk_platform_repositories[platform] = name
+    hermetic_android_sdk_repository(
+        name = "androidsdk",
+        platform_repositories = sdk_platform_repositories,
+        **sdk
+    )
+
+    ndk_platform_repositories = {}
+    for platform in NDK_PLATFORMS:
+        name = "androidndk_{}".format(platform)
+        hermetic_android_ndk_platform_repository(
+            name = name,
+            platform = platform,
+            **ndk
+        )
+        ndk_platform_repositories[platform] = name
+    hermetic_android_ndk_repository(
+        name = "androidndk",
+        platform_repositories = ndk_platform_repositories,
+        **ndk
+    )
 
     return module_ctx.extension_metadata(reproducible = True)
 
@@ -71,4 +112,6 @@ android = module_extension(
         "ndk": NDK_TAG,
         "sdk": SDK_TAG,
     },
+    os_dependent = False,
+    arch_dependent = False,
 )

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -3,15 +3,14 @@
 load(
     "//ndk:repositories.bzl",
     "ANDROID_NDK_LICENSE_ENV",
-    "NDK_PLATFORMS",
     "NDK_TAG",
     "hermetic_android_ndk_platform_repository",
     "hermetic_android_ndk_repository",
 )
+load("//private:utils.bzl", "ANDROID_PLATFORMS")
 load(
     "//sdk:repositories.bzl",
     "ANDROID_SDK_LICENSE_ENV",
-    "SDK_PLATFORMS",
     "SDK_TAG",
     "hermetic_android_sdk_platform_repository",
     "hermetic_android_sdk_repository",
@@ -71,7 +70,7 @@ def _android_impl(module_ctx):
     ndk = _ndk_kwargs(_single_root_tag(module_ctx, "ndk"))
 
     sdk_platform_repositories = {}
-    for platform in SDK_PLATFORMS:
+    for platform in sorted(ANDROID_PLATFORMS.keys()):
         name = "androidsdk_{}".format(platform)
         hermetic_android_sdk_platform_repository(
             name = name,
@@ -86,7 +85,7 @@ def _android_impl(module_ctx):
     )
 
     ndk_platform_repositories = {}
-    for platform in NDK_PLATFORMS:
+    for platform in sorted(ANDROID_PLATFORMS.keys()):
         name = "androidndk_{}".format(platform)
         hermetic_android_ndk_platform_repository(
             name = name,

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -111,6 +111,4 @@ android = module_extension(
         "ndk": NDK_TAG,
         "sdk": SDK_TAG,
     },
-    os_dependent = False,
-    arch_dependent = False,
 )

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -129,13 +129,13 @@ def _ndk_for_platform(ndk, platform):
     platform_ndk["platforms"] = [platform]
     return platform_ndk
 
-def _facade_ndk_select_alias(rctx, ndk, name, target):
+def _platform_redirect_alias(rctx, ndk, name, target):
     return _select_alias(name, [
         (_platform_condition(platform), _external_label(_platform_repository(rctx, platform, "NDK"), target))
         for platform in ndk["platforms"]
     ])
 
-def _facade_platform_toolchains(rctx, ndk):
+def _platform_redirect_toolchains(rctx, ndk):
     toolchains = []
     for platform in ndk["platforms"]:
         repository = _platform_repository(rctx, platform, "NDK")
@@ -145,7 +145,7 @@ def _facade_platform_toolchains(rctx, ndk):
             toolchains.append((name, toolchain_pattern, constraints))
     return repr(toolchains)
 
-def _facade_toolchain_suite_alias(rctx, ndk):
+def _platform_redirect_toolchain_suite_alias(rctx, ndk):
     return _select_alias("toolchain", [
         (
             _platform_condition(platform),
@@ -157,14 +157,14 @@ def _facade_toolchain_suite_alias(rctx, ndk):
         for platform in ndk["platforms"]
     ])
 
-def _facade_build_file_content(rctx, ndk):
+def _platform_redirect_build_file_content(rctx, ndk):
     aliases = [
-        _facade_toolchain_suite_alias(rctx, ndk),
-        _facade_ndk_select_alias(rctx, ndk, "cpufeatures", "cpufeatures"),
-        _facade_ndk_select_alias(rctx, ndk, "native_app_glue", "native_app_glue"),
-        _facade_ndk_select_alias(rctx, ndk, "sources/android/native_app_glue/android_native_app_glue.h", "sources/android/native_app_glue/android_native_app_glue.h"),
+        _platform_redirect_toolchain_suite_alias(rctx, ndk),
+        _platform_redirect_alias(rctx, ndk, "cpufeatures", "cpufeatures"),
+        _platform_redirect_alias(rctx, ndk, "native_app_glue", "native_app_glue"),
+        _platform_redirect_alias(rctx, ndk, "sources/android/native_app_glue/android_native_app_glue.h", "sources/android/native_app_glue/android_native_app_glue.h"),
     ]
-    return """\"\"\"Generated Android NDK facade repository.\"\"\"
+    return """\"\"\"Generated Android NDK platform redirect repository.\"\"\"
 
 load("//:platform_toolchains.bzl", "PLATFORM_TOOLCHAINS")
 load("//:target_systems.bzl", "CPU_CONSTRAINT", "TARGET_SYSTEM_NAMES")
@@ -285,9 +285,9 @@ def _hermetic_android_ndk_repository_impl(rctx):
 
     rctx.file(
         "platform_toolchains.bzl",
-        "PLATFORM_TOOLCHAINS = {}\n".format(_facade_platform_toolchains(rctx, ndk)),
+        "PLATFORM_TOOLCHAINS = {}\n".format(_platform_redirect_toolchains(rctx, ndk)),
     )
-    rctx.file("BUILD.bazel", _facade_build_file_content(rctx, ndk))
+    rctx.file("BUILD.bazel", _platform_redirect_build_file_content(rctx, ndk))
     rctx.template(
         "target_systems.bzl",
         rctx.attr._template_target_systems,

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -1,6 +1,19 @@
 """Repository rule for downloading a hermetic Android NDK."""
 
 load("//ndk:versions.bzl", "DEFAULT_API_LEVEL", "NDK_VERSIONS")
+load(
+    "//private:utils.bzl",
+    "ANDROID_PLATFORMS",
+    _archive_attrs = "archive_attrs",
+    _check_known_platforms = "check_known_platforms",
+    _check_matching_platforms = "check_matching_platforms",
+    _external_label = "external_label",
+    _format_platforms = "format_platforms",
+    _platform_condition = "platform_condition",
+    _platform_repository = "platform_repository",
+    _require_license = "require_license",
+    _select_alias = "select_alias",
+)
 
 ANDROID_NDK_LICENSE_ENV = "ACCEPTED_ANDROID_NDK_LICENSE_VERSION"
 
@@ -23,89 +36,30 @@ NDK_TAG = tag_class(attrs = {
     ),
 })
 
-_PLATFORMS = {
-    "darwin": {
-        "clang_directory": "toolchains/llvm/prebuilt/darwin-x86_64",
-        "constraints": [
-            ("darwin", ["@platforms//os:macos"]),
-        ],
-        "executable_extension": "",
-    },
-    "linux": {
-        "clang_directory": "toolchains/llvm/prebuilt/linux-x86_64",
-        "constraints": [
-            ("linux", ["@platforms//os:linux", "@platforms//cpu:x86_64"]),
-        ],
-        "executable_extension": "",
-    },
-    "windows": {
-        "clang_directory": "toolchains/llvm/prebuilt/windows-x86_64",
-        "constraints": [
-            ("windows", ["@platforms//os:windows", "@platforms//cpu:x86_64"]),
-        ],
-        "executable_extension": ".exe",
-    },
+_CLANG_DIRECTORIES = {
+    "darwin": "toolchains/llvm/prebuilt/darwin-x86_64",
+    "linux": "toolchains/llvm/prebuilt/linux-x86_64",
+    "windows": "toolchains/llvm/prebuilt/windows-x86_64",
 }
 
+def _platforms():
+    platforms = {}
+    for platform, metadata in ANDROID_PLATFORMS.items():
+        platform_metadata = dict(metadata)
+        platform_metadata["clang_directory"] = _CLANG_DIRECTORIES[platform]
+        platforms[platform] = platform_metadata
+    return platforms
+
+_PLATFORMS = _platforms()
+
 NDK_PLATFORMS = sorted(_PLATFORMS.keys())
-
-def _require_license(rctx):
-    value = rctx.getenv(ANDROID_NDK_LICENSE_ENV)
-    if value != rctx.attr.version:
-        fail("""\
-Before using the hermetic Android NDK toolchain you must read and accept the license for the current version. Once you have done so, add this in your '.bazelrc':
-
-common --repo_env={}={}
-
-Current {} value was {}.""".format(
-            ANDROID_NDK_LICENSE_ENV,
-            rctx.attr.version,
-            ANDROID_NDK_LICENSE_ENV,
-            value or "unset",
-        ))
-
-def _archive_url(archive):
-    if archive.get("url"):
-        return archive["url"]
-    return "https://dl.google.com/android/repository/{}".format(archive["file"])
-
-def _archive_attrs(archives):
-    urls = {}
-    sha256s = {}
-    for platform, archive in archives.items():
-        urls[platform] = _archive_url(archive)
-        sha256s[platform] = archive["sha256"]
-    return urls, sha256s
-
-def _format_platforms(platforms):
-    return ", ".join(sorted(platforms))
-
-def _check_known_platforms(values, attr_name):
-    keys = sorted(values.keys())
-    unknown = [platform for platform in keys if platform not in _PLATFORMS]
-    if unknown:
-        fail("{} contains unsupported platforms: [{}]. Expected keys from [{}].".format(
-            attr_name,
-            _format_platforms(unknown),
-            _format_platforms(_PLATFORMS.keys()),
-        ))
-
-def _check_matching_platforms(values, attr_name, platforms):
-    keys = sorted(values.keys())
-    expected = sorted(platforms)
-    if keys != expected:
-        fail("{} must use the same platforms as urls: got [{}], expected [{}].".format(
-            attr_name,
-            _format_platforms(keys),
-            _format_platforms(expected),
-        ))
 
 def _custom_archives(rctx):
     if not rctx.attr.urls or not rctx.attr.sha256s:
         fail("Custom Android NDK archives for version {} require both urls and sha256s.".format(repr(rctx.attr.version)))
     if not rctx.attr.strip_prefix:
         fail("Custom Android NDK archives for version {} require strip_prefix.".format(repr(rctx.attr.version)))
-    _check_known_platforms(rctx.attr.urls, "urls")
+    _check_known_platforms(rctx.attr.urls, "urls", _PLATFORMS.keys())
     platforms = sorted(rctx.attr.urls.keys())
     _check_matching_platforms(rctx.attr.sha256s, "sha256s", platforms)
     return {
@@ -177,50 +131,16 @@ def _ndk_for_platform(ndk, platform):
     platform_ndk["platforms"] = [platform]
     return platform_ndk
 
-def _platform_condition(platform):
-    if platform == "linux":
-        return ":linux_x86_64_exec"
-    if platform == "darwin":
-        return ":darwin_exec"
-    if platform == "windows":
-        return ":windows_x86_64_exec"
-    fail("Unsupported platform {}.".format(repr(platform)))
-
-def _external_label(repository, target):
-    return "@{}//:{}".format(repository, target)
-
-def _platform_repository(rctx, platform):
-    if platform not in rctx.attr.platform_repositories:
-        fail("Missing platform repository for Android NDK platform {}. Got [{}].".format(
-            repr(platform),
-            _format_platforms(rctx.attr.platform_repositories.keys()),
-        ))
-    return rctx.attr.platform_repositories[platform]
-
-def _select_alias(name, entries):
-    lines = [
-        "alias(",
-        "    name = \"{}\",".format(name),
-        "    actual = select({",
-    ]
-    for condition, actual in entries:
-        lines.append("        \"{}\": \"{}\",".format(condition, actual))
-    lines.extend([
-        "    }),",
-        ")",
-    ])
-    return "\n".join(lines)
-
 def _facade_ndk_select_alias(rctx, ndk, name, target):
     return _select_alias(name, [
-        (_platform_condition(platform), _external_label(_platform_repository(rctx, platform), target))
+        (_platform_condition(platform), _external_label(_platform_repository(rctx, platform, "NDK"), target))
         for platform in ndk["platforms"]
     ])
 
 def _facade_platform_toolchains(rctx, ndk):
     toolchains = []
     for platform in ndk["platforms"]:
-        repository = _platform_repository(rctx, platform)
+        repository = _platform_repository(rctx, platform, "NDK")
         clang_directory = _PLATFORMS[platform]["clang_directory"]
         toolchain_pattern = "@{}//{}:cc_toolchain_{{}}".format(repository, clang_directory)
         for name, constraints in _PLATFORMS[platform]["constraints"]:
@@ -232,7 +152,7 @@ def _facade_toolchain_suite_alias(rctx, ndk):
         (
             _platform_condition(platform),
             "@{}//{}:cc_toolchain_suite".format(
-                _platform_repository(rctx, platform),
+                _platform_repository(rctx, platform, "NDK"),
                 _PLATFORMS[platform]["clang_directory"],
             ),
         )
@@ -303,7 +223,7 @@ def _hermetic_android_ndk_platform_repository_impl(rctx):
     if not rctx.attr.version:
         fail("hermetic_android_ndk_platform_repository requires version.")
 
-    _require_license(rctx)
+    _require_license(rctx, ANDROID_NDK_LICENSE_ENV, "NDK")
     ndk = _ndk_for_platform(_resolve_ndk(rctx), rctx.attr.platform)
     _download_ndk(rctx, ndk)
 
@@ -362,7 +282,7 @@ def _hermetic_android_ndk_repository_impl(rctx):
     if not rctx.attr.version:
         fail("hermetic_android_ndk_repository requires version.")
 
-    _require_license(rctx)
+    _require_license(rctx, ANDROID_NDK_LICENSE_ENV, "NDK")
     ndk = _resolve_ndk(rctx)
 
     rctx.file(

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -52,14 +52,12 @@ def _platforms():
 
 _PLATFORMS = _platforms()
 
-NDK_PLATFORMS = sorted(_PLATFORMS.keys())
-
 def _custom_archives(rctx):
     if not rctx.attr.urls or not rctx.attr.sha256s:
         fail("Custom Android NDK archives for version {} require both urls and sha256s.".format(repr(rctx.attr.version)))
     if not rctx.attr.strip_prefix:
         fail("Custom Android NDK archives for version {} require strip_prefix.".format(repr(rctx.attr.version)))
-    _check_known_platforms(rctx.attr.urls, "urls", _PLATFORMS.keys())
+    _check_known_platforms(rctx.attr.urls, "urls")
     platforms = sorted(rctx.attr.urls.keys())
     _check_matching_platforms(rctx.attr.sha256s, "sha256s", platforms)
     return {
@@ -78,7 +76,7 @@ def _resolve_ndk(rctx):
         ndk = _custom_archives(rctx)
     elif rctx.attr.version in versions:
         known = versions[rctx.attr.version]
-        urls, sha256s = _archive_attrs(known["archives"])
+        urls, sha256s = _archive_attrs(known["archives"], include_strip_prefixes = False)
         ndk = {
             "platforms": sorted(urls.keys()),
             "sha256s": sha256s,
@@ -249,7 +247,7 @@ hermetic_android_ndk_platform_repository = repository_rule(
     implementation = _hermetic_android_ndk_platform_repository_impl,
     attrs = {
         "api_level": attr.int(),
-        "platform": attr.string(mandatory = True, values = NDK_PLATFORMS),
+        "platform": attr.string(mandatory = True, values = sorted(_PLATFORMS.keys())),
         "sha256s": attr.string_dict(),
         "strip_prefix": attr.string(),
         "urls": attr.string_dict(),

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -47,6 +47,8 @@ _PLATFORMS = {
     },
 }
 
+NDK_PLATFORMS = sorted(_PLATFORMS.keys())
+
 def _require_license(rctx):
     value = rctx.getenv(ANDROID_NDK_LICENSE_ENV)
     if value != rctx.attr.version:
@@ -165,6 +167,110 @@ def _platform_toolchains(platforms):
             toolchains.append((name, clang_directory, constraints))
     return repr(toolchains)
 
+def _ndk_for_platform(ndk, platform):
+    if platform not in ndk["platforms"]:
+        fail("Android NDK archives are not available for platform {}. Available platforms: [{}].".format(
+            repr(platform),
+            _format_platforms(ndk["platforms"]),
+        ))
+    platform_ndk = dict(ndk)
+    platform_ndk["platforms"] = [platform]
+    return platform_ndk
+
+def _platform_condition(platform):
+    if platform == "linux":
+        return ":linux_x86_64_exec"
+    if platform == "darwin":
+        return ":darwin_exec"
+    if platform == "windows":
+        return ":windows_x86_64_exec"
+    fail("Unsupported platform {}.".format(repr(platform)))
+
+def _external_label(repository, target):
+    return "@{}//:{}".format(repository, target)
+
+def _platform_repository(rctx, platform):
+    if platform not in rctx.attr.platform_repositories:
+        fail("Missing platform repository for Android NDK platform {}. Got [{}].".format(
+            repr(platform),
+            _format_platforms(rctx.attr.platform_repositories.keys()),
+        ))
+    return rctx.attr.platform_repositories[platform]
+
+def _select_alias(name, entries):
+    lines = [
+        "alias(",
+        "    name = \"{}\",".format(name),
+        "    actual = select({",
+    ]
+    for condition, actual in entries:
+        lines.append("        \"{}\": \"{}\",".format(condition, actual))
+    lines.extend([
+        "    }),",
+        ")",
+    ])
+    return "\n".join(lines)
+
+def _facade_ndk_select_alias(rctx, ndk, name, target):
+    return _select_alias(name, [
+        (_platform_condition(platform), _external_label(_platform_repository(rctx, platform), target))
+        for platform in ndk["platforms"]
+    ])
+
+def _facade_platform_toolchains(rctx, ndk):
+    toolchains = []
+    for platform in ndk["platforms"]:
+        repository = _platform_repository(rctx, platform)
+        clang_directory = _PLATFORMS[platform]["clang_directory"]
+        toolchain_pattern = "@{}//{}:cc_toolchain_{{}}".format(repository, clang_directory)
+        for name, constraints in _PLATFORMS[platform]["constraints"]:
+            toolchains.append((name, toolchain_pattern, constraints))
+    return repr(toolchains)
+
+def _facade_toolchain_suite_alias(rctx, ndk):
+    return _select_alias("toolchain", [
+        (
+            _platform_condition(platform),
+            "@{}//{}:cc_toolchain_suite".format(
+                _platform_repository(rctx, platform),
+                _PLATFORMS[platform]["clang_directory"],
+            ),
+        )
+        for platform in ndk["platforms"]
+    ])
+
+def _facade_build_file_content(rctx, ndk):
+    aliases = [
+        _facade_toolchain_suite_alias(rctx, ndk),
+        _facade_ndk_select_alias(rctx, ndk, "cpufeatures", "cpufeatures"),
+        _facade_ndk_select_alias(rctx, ndk, "native_app_glue", "native_app_glue"),
+        _facade_ndk_select_alias(rctx, ndk, "sources/android/native_app_glue/android_native_app_glue.h", "sources/android/native_app_glue/android_native_app_glue.h"),
+    ]
+    return """\"\"\"Generated Android NDK facade repository.\"\"\"
+
+load("//:platform_toolchains.bzl", "PLATFORM_TOOLCHAINS")
+load("//:target_systems.bzl", "CPU_CONSTRAINT", "TARGET_SYSTEM_NAMES")
+
+package(default_visibility = ["//visibility:public"])
+
+[
+    toolchain(
+        name = "toolchain_{{}}_{{}}".format(platform_name, target_system_name),
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = [
+            "@platforms//os:android",
+            CPU_CONSTRAINT[target_system_name],
+        ],
+        toolchain = toolchain_pattern.format(target_system_name),
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
+    for platform_name, toolchain_pattern, exec_compatible_with in PLATFORM_TOOLCHAINS
+    for target_system_name in TARGET_SYSTEM_NAMES
+]
+
+{aliases}
+""".format(aliases = "\n\n".join(aliases))
+
 def _generate_platform_build_files(rctx, ndk):
     repository_name = rctx.attr._rules_android_ndk_build.workspace_name
     for platform in ndk["platforms"]:
@@ -193,12 +299,12 @@ def _generate_platform_build_files(rctx, ndk):
             },
         )
 
-def _hermetic_android_ndk_repository_impl(rctx):
+def _hermetic_android_ndk_platform_repository_impl(rctx):
     if not rctx.attr.version:
-        fail("hermetic_android_ndk_repository requires version.")
+        fail("hermetic_android_ndk_platform_repository requires version.")
 
     _require_license(rctx)
-    ndk = _resolve_ndk(rctx)
+    ndk = _ndk_for_platform(_resolve_ndk(rctx), rctx.attr.platform)
     _download_ndk(rctx, ndk)
 
     rctx.file("ndk/.keep", "")
@@ -219,10 +325,11 @@ def _hermetic_android_ndk_repository_impl(rctx):
         return rctx.repo_metadata(reproducible = True)
     return None
 
-hermetic_android_ndk_repository = repository_rule(
-    implementation = _hermetic_android_ndk_repository_impl,
+hermetic_android_ndk_platform_repository = repository_rule(
+    implementation = _hermetic_android_ndk_platform_repository_impl,
     attrs = {
         "api_level": attr.int(),
+        "platform": attr.string(mandatory = True, values = NDK_PLATFORMS),
         "sha256s": attr.string_dict(),
         "strip_prefix": attr.string(),
         "urls": attr.string_dict(),
@@ -239,6 +346,49 @@ hermetic_android_ndk_repository = repository_rule(
             default = Label("@rules_android_ndk//:BUILD.ndk_sysroot.tpl"),
             allow_single_file = True,
         ),
+        "_template_target_systems": attr.label(
+            default = Label("@rules_android_ndk//:target_systems.bzl.tpl"),
+            allow_single_file = True,
+        ),
+        "_versions_json": attr.label(
+            default = NDK_VERSIONS,
+            allow_single_file = True,
+        ),
+    },
+    environ = [ANDROID_NDK_LICENSE_ENV],
+)
+
+def _hermetic_android_ndk_repository_impl(rctx):
+    if not rctx.attr.version:
+        fail("hermetic_android_ndk_repository requires version.")
+
+    _require_license(rctx)
+    ndk = _resolve_ndk(rctx)
+
+    rctx.file(
+        "platform_toolchains.bzl",
+        "PLATFORM_TOOLCHAINS = {}\n".format(_facade_platform_toolchains(rctx, ndk)),
+    )
+    rctx.file("BUILD.bazel", _facade_build_file_content(rctx, ndk))
+    rctx.template(
+        "target_systems.bzl",
+        rctx.attr._template_target_systems,
+        {},
+    )
+
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
+
+hermetic_android_ndk_repository = repository_rule(
+    implementation = _hermetic_android_ndk_repository_impl,
+    attrs = {
+        "api_level": attr.int(),
+        "platform_repositories": attr.string_dict(mandatory = True),
+        "sha256s": attr.string_dict(),
+        "strip_prefix": attr.string(),
+        "urls": attr.string_dict(),
+        "version": attr.string(mandatory = True),
         "_template_target_systems": attr.label(
             default = Label("@rules_android_ndk//:target_systems.bzl.tpl"),
             allow_single_file = True,

--- a/ndk/versions.json
+++ b/ndk/versions.json
@@ -102,6 +102,23 @@
         }
       }
     },
+    "29.0.13846066": {
+      "strip_prefix": "android-ndk-r29-beta3",
+      "archives": {
+        "darwin": {
+          "file": "android-ndk-r29-beta3-darwin.zip",
+          "sha256": "8e9db80c3691fef72ca0c01768d87b5aca2afba80de1dd99289ef646e9e0a725"
+        },
+        "linux": {
+          "file": "android-ndk-r29-beta3-linux.zip",
+          "sha256": "ca0eaac8f992635a4a74c2927e2e76d788f18b8ba52c668ddc7f675fe6265d48"
+        },
+        "windows": {
+          "file": "android-ndk-r29-beta3-windows.zip",
+          "sha256": "02a7c77197fad386807f442c9f7c791041a10f050d0c446b46dd0e9e77112ff5"
+        }
+      }
+    },
     "r29": {
       "strip_prefix": "android-ndk-r29",
       "archives": {

--- a/private/utils.bzl
+++ b/private/utils.bzl
@@ -50,7 +50,7 @@ def archive_url(archive):
         return archive["url"]
     return "https://dl.google.com/android/repository/{}".format(archive["file"])
 
-def archive_attrs(archives, include_strip_prefixes = False):
+def archive_attrs(archives, include_strip_prefixes):
     """Splits archive metadata into URL, SHA-256, and optional strip-prefix maps.
 
     Args:
@@ -76,16 +76,16 @@ def format_platforms(platforms):
     """Formats platform names for diagnostics."""
     return ", ".join(sorted(platforms))
 
-def check_known_platforms(values, attr_name, valid_platforms, what = ""):
+def check_known_platforms(values, attr_name, what = ""):
     """Fails if an attribute map contains unsupported platform keys.
 
     Args:
       values: Attribute map keyed by platform.
       attr_name: Attribute name to use in diagnostics.
-      valid_platforms: Supported platform names.
       what: Optional component name to use in diagnostics.
     """
     keys = sorted(values.keys())
+    valid_platforms = ANDROID_PLATFORMS.keys()
     unknown = [platform for platform in keys if platform not in valid_platforms]
     if unknown:
         if what:

--- a/private/utils.bzl
+++ b/private/utils.bzl
@@ -1,0 +1,179 @@
+"""Shared helpers for Android SDK and NDK repository rules."""
+
+ANDROID_PLATFORMS = {
+    "darwin": {
+        "constraints": [
+            ("darwin", ["@platforms//os:macos"]),
+        ],
+        "executable_extension": "",
+    },
+    "linux": {
+        "constraints": [
+            ("linux", ["@platforms//os:linux", "@platforms//cpu:x86_64"]),
+        ],
+        "executable_extension": "",
+    },
+    "windows": {
+        "constraints": [
+            ("windows", ["@platforms//os:windows", "@platforms//cpu:x86_64"]),
+        ],
+        "executable_extension": ".exe",
+    },
+}
+
+_PLATFORM_CONDITIONS = {
+    "darwin": ":darwin_exec",
+    "linux": ":linux_x86_64_exec",
+    "windows": ":windows_x86_64_exec",
+}
+
+def require_license(rctx, license_env, component):
+    """Fails unless the repository rule's version has been accepted."""
+    value = rctx.getenv(license_env)
+    if value != rctx.attr.version:
+        fail("""\
+Before using the hermetic Android {} toolchain you must read and accept the license for the current version. Once you have done so, add this in your '.bazelrc':
+
+common --repo_env={}={}
+
+Current {} value was {}.""".format(
+            component,
+            license_env,
+            rctx.attr.version,
+            license_env,
+            value or "unset",
+        ))
+
+def archive_url(archive):
+    """Returns a download URL from an archive metadata entry."""
+    if archive.get("url"):
+        return archive["url"]
+    return "https://dl.google.com/android/repository/{}".format(archive["file"])
+
+def archive_attrs(archives, include_strip_prefixes = False):
+    """Splits archive metadata into URL, SHA-256, and optional strip-prefix maps.
+
+    Args:
+      archives: Archive metadata keyed by platform.
+      include_strip_prefixes: Whether to return a strip-prefix map.
+
+    Returns:
+      A tuple of URL and SHA-256 maps, plus strip prefixes when requested.
+    """
+    urls = {}
+    sha256s = {}
+    strip_prefixes = {}
+    for platform, archive in archives.items():
+        urls[platform] = archive_url(archive)
+        sha256s[platform] = archive["sha256"]
+        if include_strip_prefixes and archive.get("strip_prefix"):
+            strip_prefixes[platform] = archive["strip_prefix"]
+    if include_strip_prefixes:
+        return urls, sha256s, strip_prefixes
+    return urls, sha256s
+
+def format_platforms(platforms):
+    """Formats platform names for diagnostics."""
+    return ", ".join(sorted(platforms))
+
+def check_known_platforms(values, attr_name, valid_platforms, what = ""):
+    """Fails if an attribute map contains unsupported platform keys.
+
+    Args:
+      values: Attribute map keyed by platform.
+      attr_name: Attribute name to use in diagnostics.
+      valid_platforms: Supported platform names.
+      what: Optional component name to use in diagnostics.
+    """
+    keys = sorted(values.keys())
+    unknown = [platform for platform in keys if platform not in valid_platforms]
+    if unknown:
+        if what:
+            fail("{} contains unsupported platforms for {}: [{}]. Expected keys from [{}].".format(
+                attr_name,
+                what,
+                format_platforms(unknown),
+                format_platforms(valid_platforms),
+            ))
+        fail("{} contains unsupported platforms: [{}]. Expected keys from [{}].".format(
+            attr_name,
+            format_platforms(unknown),
+            format_platforms(valid_platforms),
+        ))
+
+def check_matching_platforms(values, attr_name, platforms, what = "", expected_attr_name = "urls"):
+    """Fails if an attribute map's platform keys differ from expected platforms.
+
+    Args:
+      values: Attribute map keyed by platform.
+      attr_name: Attribute name to use in diagnostics.
+      platforms: Expected platform names.
+      what: Optional component name to use in diagnostics.
+      expected_attr_name: Attribute name that defines the expected platforms.
+    """
+    keys = sorted(values.keys())
+    expected = sorted(platforms)
+    if keys != expected:
+        if what:
+            fail("{} must use the same platforms as {}_urls for {}: got [{}], expected [{}].".format(
+                attr_name,
+                what,
+                what,
+                format_platforms(keys),
+                format_platforms(expected),
+            ))
+        fail("{} must use the same platforms as {}: got [{}], expected [{}].".format(
+            attr_name,
+            expected_attr_name,
+            format_platforms(keys),
+            format_platforms(expected),
+        ))
+
+def platform_condition(platform):
+    """Returns the config_setting label for an Android host platform."""
+    if platform in _PLATFORM_CONDITIONS:
+        return _PLATFORM_CONDITIONS[platform]
+    fail("Unsupported platform {}.".format(repr(platform)))
+
+def external_label(repository, target):
+    """Returns a root target label in an external repository."""
+    return "@{}//:{}".format(repository, target)
+
+def platform_repository(rctx, platform, component):
+    """Returns the configured platform repository name for a facade repository."""
+    if platform not in rctx.attr.platform_repositories:
+        fail("Missing platform repository for Android {} platform {}. Got [{}].".format(
+            component,
+            repr(platform),
+            format_platforms(rctx.attr.platform_repositories.keys()),
+        ))
+    return rctx.attr.platform_repositories[platform]
+
+def _string_list(values):
+    return "[{}]".format(", ".join(["\"{}\"".format(value) for value in values]))
+
+def select_alias(name, entries, tags = None):
+    """Returns an alias rule string backed by a select expression.
+
+    Args:
+      name: Alias rule name.
+      entries: Pairs of condition labels and selected target labels.
+      tags: Optional tags for the generated alias rule.
+
+    Returns:
+      A BUILD-file fragment defining the alias.
+    """
+    lines = [
+        "alias(",
+        "    name = \"{}\",".format(name),
+        "    actual = select({",
+    ]
+    for condition, actual in entries:
+        lines.append("        \"{}\": \"{}\",".format(condition, actual))
+    lines.extend([
+        "    }),",
+    ])
+    if tags:
+        lines.append("    tags = {},".format(_string_list(tags)))
+    lines.append(")")
+    return "\n".join(lines)

--- a/private/utils.bzl
+++ b/private/utils.bzl
@@ -140,7 +140,7 @@ def external_label(repository, target):
     return "@{}//:{}".format(repository, target)
 
 def platform_repository(rctx, platform, component):
-    """Returns the configured platform repository name for a facade repository."""
+    """Returns the configured platform repository name for a redirecting repository."""
     if platform not in rctx.attr.platform_repositories:
         fail("Missing platform repository for Android {} platform {}. Got [{}].".format(
             component,

--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -78,7 +78,10 @@ alias(
 
 %{optional_java_imports}
 
-%{core_for_system_modules_rule}
+java_import(
+    name = "core-for-system-modules-jar",
+    jars = ["platforms/android-%{api_level}/core-for-system-modules.jar"],
+)
 
 java_binary(
     name = "d8_compat_dx",
@@ -162,17 +165,17 @@ android_sdk(
     aapt2 = ":aapt2",
     adb = ":adb",
     aidl = ":aidl",
-    android_jar = %{android_jar},
+    android_jar = "platforms/android-%{api_level}/android.jar",
     apksigner = ":apksigner",
     build_tools_version = "%{build_tools_version}",
     dexdump = ":dexdump",
     dx = ":d8_compat_dx",
-    framework_aidl = %{framework_aidl},
+    framework_aidl = "platforms/android-%{api_level}/framework.aidl",
     legacy_main_dex_list_generator = ":generate_main_dex_list",
     main_dex_classes = ":main_dex_classes",
     main_dex_list_creator = ":main_dex_list_creator",
     proguard = "@remote_java_tools//:proguard",
-    source_properties = %{source_properties},
+    source_properties = "platforms/android-%{api_level}/source.properties",
     tags = [
         "__ANDROID_RULES_MIGRATION__",
         "manual",
@@ -191,7 +194,14 @@ toolchain(
 
 filegroup(
     name = "files",
-    srcs = %{files_srcs},
+    srcs = [
+        "platforms/android-%{api_level}/android.jar",
+        "platforms/android-%{api_level}/core-for-system-modules.jar",
+        "platforms/android-%{api_level}/framework.aidl",
+    ],
 )
 
-%{sdk_path_rule}
+filegroup(
+    name = "sdk_path",
+    srcs = ["."],
+)

--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -78,10 +78,7 @@ alias(
 
 %{optional_java_imports}
 
-java_import(
-    name = "core-for-system-modules-jar",
-    jars = ["platforms/android-%{api_level}/core-for-system-modules.jar"],
-)
+%{core_for_system_modules_rule}
 
 java_binary(
     name = "d8_compat_dx",
@@ -165,17 +162,17 @@ android_sdk(
     aapt2 = ":aapt2",
     adb = ":adb",
     aidl = ":aidl",
-    android_jar = "platforms/android-%{api_level}/android.jar",
+    android_jar = %{android_jar},
     apksigner = ":apksigner",
     build_tools_version = "%{build_tools_version}",
     dexdump = ":dexdump",
     dx = ":d8_compat_dx",
-    framework_aidl = "platforms/android-%{api_level}/framework.aidl",
+    framework_aidl = %{framework_aidl},
     legacy_main_dex_list_generator = ":generate_main_dex_list",
     main_dex_classes = ":main_dex_classes",
     main_dex_list_creator = ":main_dex_list_creator",
     proguard = "@remote_java_tools//:proguard",
-    source_properties = "platforms/android-%{api_level}/source.properties",
+    source_properties = %{source_properties},
     tags = [
         "__ANDROID_RULES_MIGRATION__",
         "manual",
@@ -194,14 +191,7 @@ toolchain(
 
 filegroup(
     name = "files",
-    srcs = [
-        "platforms/android-%{api_level}/android.jar",
-        "platforms/android-%{api_level}/core-for-system-modules.jar",
-        "platforms/android-%{api_level}/framework.aidl",
-    ],
+    srcs = %{files_srcs},
 )
 
-filegroup(
-    name = "sdk_path",
-    srcs = ["."],
-)
+%{sdk_path_rule}

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -547,25 +547,6 @@ def _sdk_for_platform(sdk, platform):
     platform_sdk["platforms"] = [platform]
     return platform_sdk
 
-def _local_core_for_system_modules_rule(api_level):
-    return """java_import(
-    name = "core-for-system-modules-jar",
-    jars = ["platforms/android-{api_level}/core-for-system-modules.jar"],
-)""".format(api_level = api_level)
-
-def _local_files_srcs(api_level):
-    return """[
-        "platforms/android-{api_level}/android.jar",
-        "platforms/android-{api_level}/core-for-system-modules.jar",
-        "platforms/android-{api_level}/framework.aidl",
-    ]""".format(api_level = api_level)
-
-def _local_sdk_path_rule():
-    return """filegroup(
-    name = "sdk_path",
-    srcs = ["."],
-)"""
-
 def _facade_select_alias(rctx, sdk, name, target):
     return _select_alias(name, [
         (_platform_condition(platform), _external_label(_platform_repository(rctx, platform, "SDK"), target))
@@ -702,16 +683,10 @@ def _hermetic_android_sdk_platform_repository_impl(rctx):
         Label("//sdk:BUILD.androidsdk.tpl"),
         substitutions = {
             "%{api_level}": sdk["api_level"],
-            "%{android_jar}": "\"platforms/android-{}/android.jar\"".format(sdk["api_level"]),
             "%{build_tools_directory}": sdk["build_tools_directory"],
             "%{build_tools_version}": sdk["build_tools_version"],
-            "%{core_for_system_modules_rule}": _local_core_for_system_modules_rule(sdk["api_level"]),
-            "%{files_srcs}": _local_files_srcs(sdk["api_level"]),
-            "%{framework_aidl}": "\"platforms/android-{}/framework.aidl\"".format(sdk["api_level"]),
             "%{platform_aliases}": _platform_aliases(sdk),
             "%{platform_rules}": _platform_rules(sdk),
-            "%{sdk_path_rule}": _local_sdk_path_rule(),
-            "%{source_properties}": "\"platforms/android-{}/source.properties\"".format(sdk["api_level"]),
             "%{optional_java_imports}": _optional_java_imports(sdk["api_level"]),
         },
     )
@@ -766,16 +741,10 @@ def _hermetic_android_sdk_repository_impl(rctx):
         Label("//sdk:BUILD.androidsdk.tpl"),
         substitutions = {
             "%{api_level}": sdk["api_level"],
-            "%{android_jar}": "\"platforms/android-{}/android.jar\"".format(sdk["api_level"]),
             "%{build_tools_directory}": sdk["build_tools_directory"],
             "%{build_tools_version}": sdk["build_tools_version"],
-            "%{core_for_system_modules_rule}": _local_core_for_system_modules_rule(sdk["api_level"]),
-            "%{files_srcs}": _local_files_srcs(sdk["api_level"]),
-            "%{framework_aidl}": "\"platforms/android-{}/framework.aidl\"".format(sdk["api_level"]),
             "%{platform_aliases}": _facade_platform_aliases(rctx, sdk),
             "%{platform_rules}": _facade_platform_rules(rctx, sdk),
-            "%{sdk_path_rule}": _local_sdk_path_rule(),
-            "%{source_properties}": "\"platforms/android-{}/source.properties\"".format(sdk["api_level"]),
             "%{optional_java_imports}": _optional_java_imports(sdk["api_level"]),
         },
     )

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -66,6 +66,8 @@ _PLATFORMS = {
     },
 }
 
+SDK_PLATFORMS = sorted(_PLATFORMS.keys())
+
 def _require_license(rctx):
     value = rctx.getenv(ANDROID_SDK_LICENSE_ENV)
     if value != rctx.attr.version:
@@ -327,12 +329,12 @@ def _script_runner(name, platform, build_tools_directory):
         tool_path = tool_path,
     )
 
-def _platform_tool(platform, build_tools_directory, tool, executable_extension):
+def _platform_tool(platform, build_tools_directory, tool):
     if platform == "windows":
         return "\"build-tools/windows/{}/{}.exe\"".format(build_tools_directory, tool)
     return "\":{}_{}\"".format(tool, platform)
 
-def _platform_rules_for(rctx, platform, sdk):
+def _platform_rules_for(platform, sdk):
     build_tools_directory = sdk["build_tools_directory"]
     executable_extension = _PLATFORMS[platform]["executable_extension"]
     blocks = []
@@ -402,17 +404,17 @@ android_toolchain(
     translation_merger = ":fail",
 )
 """.format(
-        aapt = _platform_tool(platform, build_tools_directory, "aapt", executable_extension),
-        aapt2 = _platform_tool(platform, build_tools_directory, "aapt2", executable_extension),
+        aapt = _platform_tool(platform, build_tools_directory, "aapt"),
+        aapt2 = _platform_tool(platform, build_tools_directory, "aapt2"),
         adb = adb,
-        aidl = _platform_tool(platform, build_tools_directory, "aidl", executable_extension),
+        aidl = _platform_tool(platform, build_tools_directory, "aidl"),
         api_level = sdk["api_level"],
         build_tools_directory = build_tools_directory,
         build_tools_version = sdk["build_tools_version"],
-        dexdump = _platform_tool(platform, build_tools_directory, "dexdump", executable_extension),
+        dexdump = _platform_tool(platform, build_tools_directory, "dexdump"),
         platform = platform,
         sdk_name = sdk_name,
-        zipalign = _platform_tool(platform, build_tools_directory, "zipalign", executable_extension),
+        zipalign = _platform_tool(platform, build_tools_directory, "zipalign"),
     ))
 
     for constraint_name, constraints in _PLATFORMS[platform]["constraints"]:
@@ -490,8 +492,8 @@ alias(
 """.format(api_level = api_level))
     return "\n".join(blocks)
 
-def _platform_rules(rctx, sdk):
-    return "\n".join([_platform_rules_for(rctx, platform, sdk) for platform in sdk["platforms"]])
+def _platform_rules(sdk):
+    return "\n".join([_platform_rules_for(platform, sdk) for platform in sdk["platforms"]])
 
 def _tool_alias_label(platform, build_tools_directory, tool):
     if platform == "windows":
@@ -527,6 +529,15 @@ def _platform_select_alias(name, platforms, linux, darwin, windows):
     if "windows" in platforms:
         entries.append((":windows_x86_64_exec", windows))
     return _select_alias(name, entries)
+
+def _platform_condition(platform):
+    if platform == "linux":
+        return ":linux_x86_64_exec"
+    if platform == "darwin":
+        return ":darwin_exec"
+    if platform == "windows":
+        return ":windows_x86_64_exec"
+    fail("Unsupported platform {}.".format(repr(platform)))
 
 def _platform_aliases(sdk):
     platforms = sdk["platforms"]
@@ -612,6 +623,155 @@ def _platform_aliases(sdk):
     ]
     return "\n\n".join(blocks)
 
+def _sdk_for_platform(sdk, platform):
+    if platform not in sdk["platforms"]:
+        fail("Android SDK archives are not available for platform {}. Available platforms: [{}].".format(
+            repr(platform),
+            _format_platforms(sdk["platforms"]),
+        ))
+    platform_sdk = dict(sdk)
+    platform_sdk["platforms"] = [platform]
+    return platform_sdk
+
+def _local_core_for_system_modules_rule(api_level):
+    return """java_import(
+    name = "core-for-system-modules-jar",
+    jars = ["platforms/android-{api_level}/core-for-system-modules.jar"],
+)""".format(api_level = api_level)
+
+def _local_files_srcs(api_level):
+    return """[
+        "platforms/android-{api_level}/android.jar",
+        "platforms/android-{api_level}/core-for-system-modules.jar",
+        "platforms/android-{api_level}/framework.aidl",
+    ]""".format(api_level = api_level)
+
+def _local_sdk_path_rule():
+    return """filegroup(
+    name = "sdk_path",
+    srcs = ["."],
+)"""
+
+def _external_label(repository, target):
+    return "@{}//:{}".format(repository, target)
+
+def _platform_repository(rctx, platform):
+    if platform not in rctx.attr.platform_repositories:
+        fail("Missing platform repository for Android SDK platform {}. Got [{}].".format(
+            repr(platform),
+            _format_platforms(rctx.attr.platform_repositories.keys()),
+        ))
+    return rctx.attr.platform_repositories[platform]
+
+def _facade_label(rctx, platform, target):
+    return _external_label(_platform_repository(rctx, platform), target)
+
+def _facade_select_alias(rctx, sdk, name, target):
+    return _select_alias(name, [
+        (_platform_condition(platform), _facade_label(rctx, platform, target))
+        for platform in sdk["platforms"]
+    ])
+
+def _facade_platform_aliases(rctx, sdk):
+    blocks = [
+        _facade_select_alias(rctx, sdk, "aapt", "aapt"),
+        _facade_select_alias(rctx, sdk, "aapt2", "aapt2"),
+        _facade_select_alias(rctx, sdk, "aapt2_binary", "aapt2_binary"),
+        _facade_select_alias(rctx, sdk, "aidl", "aidl"),
+        _facade_select_alias(rctx, sdk, "adb", "adb"),
+        _facade_select_alias(rctx, sdk, "platform-tools/adb", "platform-tools/adb"),
+        _facade_select_alias(rctx, sdk, "apksigner", "apksigner"),
+        _facade_select_alias(rctx, sdk, "dexdump", "dexdump"),
+        _facade_select_alias(rctx, sdk, "main_dex_classes", "main_dex_classes"),
+        _facade_select_alias(rctx, sdk, "zipalign", "zipalign"),
+        _facade_select_alias(rctx, sdk, "zipalign_binary", "zipalign_binary"),
+    ]
+    return "\n\n".join(blocks)
+
+def _facade_platform_rules_for(rctx, platform, sdk):
+    repository = _platform_repository(rctx, platform)
+    sdk_name = "sdk_{}".format(platform)
+    build_tools_version = sdk["build_tools_version"]
+    blocks = []
+
+    blocks.append("""android_sdk(
+    name = "{sdk_name}",
+    aapt = "@{repository}//:aapt",
+    aapt2 = "@{repository}//:aapt2",
+    adb = "@{repository}//:adb",
+    aidl = "@{repository}//:aidl",
+    android_jar = "platforms/android-{api_level}/android.jar",
+    apksigner = "@{repository}//:apksigner",
+    build_tools_version = "{build_tools_version}",
+    dexdump = "@{repository}//:dexdump",
+    dx = ":d8_compat_dx",
+    framework_aidl = "platforms/android-{api_level}/framework.aidl",
+    legacy_main_dex_list_generator = ":generate_main_dex_list",
+    main_dex_classes = "@{repository}//:main_dex_classes",
+    main_dex_list_creator = ":main_dex_list_creator",
+    proguard = "@remote_java_tools//:proguard",
+    source_properties = "platforms/android-{api_level}/source.properties",
+    tags = ["__ANDROID_RULES_MIGRATION__"],
+    zipalign = "@{repository}//:zipalign",
+)
+
+android_toolchain(
+    name = "android_default_{platform}",
+    aapt2 = "@{repository}//:aapt2",
+    adb = "@{repository}//:adb",
+    android_archive_jar_optimization_inputs_validator = ":fail",
+    android_archive_packages_validator = ":fail",
+    apk_to_bundle_tool = ":fail",
+    centralize_r_class_tool = ":fail",
+    desugar_globals_jar = ":fail",
+    merge_baseline_profiles_tool = ":fail",
+    object_method_rewriter = ":fail",
+    profgen = ":fail",
+    proto_map_generator = ":fail",
+    translation_merger = ":fail",
+)
+""".format(
+        api_level = sdk["api_level"],
+        build_tools_version = build_tools_version,
+        platform = platform,
+        repository = repository,
+        sdk_name = sdk_name,
+    ))
+
+    for constraint_name, constraints in _PLATFORMS[platform]["constraints"]:
+        local_name = constraint_name if platform == "darwin" else platform
+        blocks.append("""toolchain(
+    name = "sdk_{local_name}_toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = ":{sdk_name}",
+    toolchain_type = ":sdk_toolchain_type",
+)
+
+toolchain(
+    name = "rules_android_sdk_{local_name}_toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = ":{sdk_name}",
+    toolchain_type = "@rules_android//toolchains/android_sdk:toolchain_type",
+)
+
+toolchain(
+    name = "android_default_{local_name}_toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = ":android_default_{platform}",
+    toolchain_type = "@rules_android//toolchains/android:toolchain_type",
+)
+""".format(
+            constraints = repr(constraints),
+            platform = platform,
+            local_name = local_name,
+            sdk_name = sdk_name,
+        ))
+
+    return "\n".join(blocks)
+
+def _facade_platform_rules(rctx, sdk):
+    return "\n".join([_facade_platform_rules_for(rctx, platform, sdk) for platform in sdk["platforms"]])
+
 def _write_runner_scripts(rctx, sdk):
     for platform in sdk["platforms"]:
         if platform == "windows":
@@ -625,14 +785,14 @@ def _write_runner_scripts(rctx, sdk):
                 executable = True,
             )
 
-def _hermetic_android_sdk_repository_impl(rctx):
+def _hermetic_android_sdk_platform_repository_impl(rctx):
     if not rctx.attr.version:
-        fail("hermetic_android_sdk_repository requires version.")
+        fail("hermetic_android_sdk_platform_repository requires version.")
     if not rctx.attr.build_tools_version:
-        fail("hermetic_android_sdk_repository requires build_tools_version.")
+        fail("hermetic_android_sdk_platform_repository requires build_tools_version.")
 
     _require_license(rctx)
-    sdk = _resolve_sdk(rctx)
+    sdk = _sdk_for_platform(_resolve_sdk(rctx), rctx.attr.platform)
     _download_sdk(rctx, sdk)
     _write_runner_scripts(rctx, sdk)
 
@@ -642,10 +802,80 @@ def _hermetic_android_sdk_repository_impl(rctx):
         Label("//sdk:BUILD.androidsdk.tpl"),
         substitutions = {
             "%{api_level}": sdk["api_level"],
+            "%{android_jar}": "\"platforms/android-{}/android.jar\"".format(sdk["api_level"]),
             "%{build_tools_directory}": sdk["build_tools_directory"],
             "%{build_tools_version}": sdk["build_tools_version"],
+            "%{core_for_system_modules_rule}": _local_core_for_system_modules_rule(sdk["api_level"]),
+            "%{files_srcs}": _local_files_srcs(sdk["api_level"]),
+            "%{framework_aidl}": "\"platforms/android-{}/framework.aidl\"".format(sdk["api_level"]),
             "%{platform_aliases}": _platform_aliases(sdk),
-            "%{platform_rules}": _platform_rules(rctx, sdk),
+            "%{platform_rules}": _platform_rules(sdk),
+            "%{sdk_path_rule}": _local_sdk_path_rule(),
+            "%{source_properties}": "\"platforms/android-{}/source.properties\"".format(sdk["api_level"]),
+            "%{optional_java_imports}": _optional_java_imports(sdk["api_level"]),
+        },
+    )
+
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
+
+hermetic_android_sdk_platform_repository = repository_rule(
+    implementation = _hermetic_android_sdk_platform_repository_impl,
+    attrs = {
+        "api_level": attr.string(),
+        "build_tools_directory": attr.string(),
+        "build_tools_sha256s": attr.string_dict(),
+        "build_tools_strip_prefixes": attr.string_dict(),
+        "build_tools_urls": attr.string_dict(),
+        "build_tools_version": attr.string(mandatory = True),
+        "platform_tools_sha256s": attr.string_dict(),
+        "platform_tools_urls": attr.string_dict(),
+        "platforms_sha256": attr.string(),
+        "platforms_strip_prefix": attr.string(),
+        "platforms_url": attr.string(),
+        "platform": attr.string(mandatory = True, values = SDK_PLATFORMS),
+        "version": attr.string(mandatory = True),
+        "_versions_json": attr.label(
+            default = SDK_VERSIONS,
+            allow_single_file = True,
+        ),
+    },
+    environ = [ANDROID_SDK_LICENSE_ENV],
+)
+
+def _hermetic_android_sdk_repository_impl(rctx):
+    if not rctx.attr.version:
+        fail("hermetic_android_sdk_repository requires version.")
+    if not rctx.attr.build_tools_version:
+        fail("hermetic_android_sdk_repository requires build_tools_version.")
+
+    _require_license(rctx)
+    sdk = _resolve_sdk(rctx)
+    _download_component(
+        rctx,
+        url = sdk["platforms_url"],
+        sha256 = sdk["platforms_sha256"],
+        output = "platforms",
+        strip_prefix = sdk["platforms_strip_prefix"],
+    )
+
+    rctx.symlink(Label("@rules_android//rules/android_sdk_repository:helper.bzl"), "helper.bzl")
+    rctx.template(
+        "BUILD.bazel",
+        Label("//sdk:BUILD.androidsdk.tpl"),
+        substitutions = {
+            "%{api_level}": sdk["api_level"],
+            "%{android_jar}": "\"platforms/android-{}/android.jar\"".format(sdk["api_level"]),
+            "%{build_tools_directory}": sdk["build_tools_directory"],
+            "%{build_tools_version}": sdk["build_tools_version"],
+            "%{core_for_system_modules_rule}": _local_core_for_system_modules_rule(sdk["api_level"]),
+            "%{files_srcs}": _local_files_srcs(sdk["api_level"]),
+            "%{framework_aidl}": "\"platforms/android-{}/framework.aidl\"".format(sdk["api_level"]),
+            "%{platform_aliases}": _facade_platform_aliases(rctx, sdk),
+            "%{platform_rules}": _facade_platform_rules(rctx, sdk),
+            "%{sdk_path_rule}": _local_sdk_path_rule(),
+            "%{source_properties}": "\"platforms/android-{}/source.properties\"".format(sdk["api_level"]),
             "%{optional_java_imports}": _optional_java_imports(sdk["api_level"]),
         },
     )
@@ -663,6 +893,7 @@ hermetic_android_sdk_repository = repository_rule(
         "build_tools_strip_prefixes": attr.string_dict(),
         "build_tools_urls": attr.string_dict(),
         "build_tools_version": attr.string(mandatory = True),
+        "platform_repositories": attr.string_dict(mandatory = True),
         "platform_tools_sha256s": attr.string_dict(),
         "platform_tools_urls": attr.string_dict(),
         "platforms_sha256": attr.string(),

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -547,29 +547,29 @@ def _sdk_for_platform(sdk, platform):
     platform_sdk["platforms"] = [platform]
     return platform_sdk
 
-def _facade_select_alias(rctx, sdk, name, target):
+def _platform_redirect_alias(rctx, sdk, name, target):
     return _select_alias(name, [
         (_platform_condition(platform), _external_label(_platform_repository(rctx, platform, "SDK"), target))
         for platform in sdk["platforms"]
     ], tags = ["manual"])
 
-def _facade_platform_aliases(rctx, sdk):
+def _platform_redirect_aliases(rctx, sdk):
     blocks = [
-        _facade_select_alias(rctx, sdk, "aapt", "aapt"),
-        _facade_select_alias(rctx, sdk, "aapt2", "aapt2"),
-        _facade_select_alias(rctx, sdk, "aapt2_binary", "aapt2_binary"),
-        _facade_select_alias(rctx, sdk, "aidl", "aidl"),
-        _facade_select_alias(rctx, sdk, "adb", "adb"),
-        _facade_select_alias(rctx, sdk, "platform-tools/adb", "platform-tools/adb"),
-        _facade_select_alias(rctx, sdk, "apksigner", "apksigner"),
-        _facade_select_alias(rctx, sdk, "dexdump", "dexdump"),
-        _facade_select_alias(rctx, sdk, "main_dex_classes", "main_dex_classes"),
-        _facade_select_alias(rctx, sdk, "zipalign", "zipalign"),
-        _facade_select_alias(rctx, sdk, "zipalign_binary", "zipalign_binary"),
+        _platform_redirect_alias(rctx, sdk, "aapt", "aapt"),
+        _platform_redirect_alias(rctx, sdk, "aapt2", "aapt2"),
+        _platform_redirect_alias(rctx, sdk, "aapt2_binary", "aapt2_binary"),
+        _platform_redirect_alias(rctx, sdk, "aidl", "aidl"),
+        _platform_redirect_alias(rctx, sdk, "adb", "adb"),
+        _platform_redirect_alias(rctx, sdk, "platform-tools/adb", "platform-tools/adb"),
+        _platform_redirect_alias(rctx, sdk, "apksigner", "apksigner"),
+        _platform_redirect_alias(rctx, sdk, "dexdump", "dexdump"),
+        _platform_redirect_alias(rctx, sdk, "main_dex_classes", "main_dex_classes"),
+        _platform_redirect_alias(rctx, sdk, "zipalign", "zipalign"),
+        _platform_redirect_alias(rctx, sdk, "zipalign_binary", "zipalign_binary"),
     ]
     return "\n\n".join(blocks)
 
-def _facade_platform_rules_for(rctx, platform, sdk):
+def _platform_redirect_rules_for(rctx, platform, sdk):
     repository = _platform_repository(rctx, platform, "SDK")
     sdk_name = "sdk_{}".format(platform)
     build_tools_version = sdk["build_tools_version"]
@@ -650,8 +650,8 @@ toolchain(
 
     return "\n".join(blocks)
 
-def _facade_platform_rules(rctx, sdk):
-    return "\n".join([_facade_platform_rules_for(rctx, platform, sdk) for platform in sdk["platforms"]])
+def _platform_redirect_rules(rctx, sdk):
+    return "\n".join([_platform_redirect_rules_for(rctx, platform, sdk) for platform in sdk["platforms"]])
 
 def _write_runner_scripts(rctx, sdk):
     for platform in sdk["platforms"]:
@@ -743,8 +743,8 @@ def _hermetic_android_sdk_repository_impl(rctx):
             "%{api_level}": sdk["api_level"],
             "%{build_tools_directory}": sdk["build_tools_directory"],
             "%{build_tools_version}": sdk["build_tools_version"],
-            "%{platform_aliases}": _facade_platform_aliases(rctx, sdk),
-            "%{platform_rules}": _facade_platform_rules(rctx, sdk),
+            "%{platform_aliases}": _platform_redirect_aliases(rctx, sdk),
+            "%{platform_rules}": _platform_redirect_rules(rctx, sdk),
             "%{optional_java_imports}": _optional_java_imports(sdk["api_level"]),
         },
     )

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -1,5 +1,19 @@
 """Repository rule for downloading a hermetic Android SDK."""
 
+load(
+    "//private:utils.bzl",
+    "ANDROID_PLATFORMS",
+    _archive_attrs = "archive_attrs",
+    _archive_url = "archive_url",
+    _check_known_platforms = "check_known_platforms",
+    _check_matching_platforms = "check_matching_platforms",
+    _external_label = "external_label",
+    _format_platforms = "format_platforms",
+    _platform_condition = "platform_condition",
+    _platform_repository = "platform_repository",
+    _require_license = "require_license",
+    _select_alias = "select_alias",
+)
 load("//sdk:versions.bzl", "SDK_VERSIONS")
 
 ANDROID_SDK_LICENSE_ENV = "ACCEPTED_ANDROID_SDK_LICENSE_VERSION"
@@ -45,85 +59,7 @@ SDK_TAG = tag_class(attrs = {
     ),
 })
 
-_PLATFORMS = {
-    "darwin": {
-        "constraints": [
-            ("darwin", ["@platforms//os:macos"]),
-        ],
-        "executable_extension": "",
-    },
-    "linux": {
-        "constraints": [
-            ("linux", ["@platforms//os:linux", "@platforms//cpu:x86_64"]),
-        ],
-        "executable_extension": "",
-    },
-    "windows": {
-        "constraints": [
-            ("windows", ["@platforms//os:windows", "@platforms//cpu:x86_64"]),
-        ],
-        "executable_extension": ".exe",
-    },
-}
-
-SDK_PLATFORMS = sorted(_PLATFORMS.keys())
-
-def _require_license(rctx):
-    value = rctx.getenv(ANDROID_SDK_LICENSE_ENV)
-    if value != rctx.attr.version:
-        fail("""\
-Before using the hermetic Android SDK toolchain you must read and accept the license for the current version. Once you have done so, add this in your '.bazelrc':
-
-common --repo_env={}={}
-
-Current {} value was {}.""".format(
-            ANDROID_SDK_LICENSE_ENV,
-            rctx.attr.version,
-            ANDROID_SDK_LICENSE_ENV,
-            value or "unset",
-        ))
-
-def _archive_url(archive):
-    if archive.get("url"):
-        return archive["url"]
-    return "https://dl.google.com/android/repository/{}".format(archive["file"])
-
-def _archive_attrs(archives):
-    urls = {}
-    sha256s = {}
-    strip_prefixes = {}
-    for platform, archive in archives.items():
-        urls[platform] = _archive_url(archive)
-        sha256s[platform] = archive["sha256"]
-        if archive.get("strip_prefix"):
-            strip_prefixes[platform] = archive["strip_prefix"]
-    return urls, sha256s, strip_prefixes
-
-def _format_platforms(platforms):
-    return ", ".join(sorted(platforms))
-
-def _check_known_platforms(values, attr_name, what):
-    keys = sorted(values.keys())
-    unknown = [platform for platform in keys if platform not in _PLATFORMS]
-    if unknown:
-        fail("{} contains unsupported platforms for {}: [{}]. Expected keys from [{}].".format(
-            attr_name,
-            what,
-            _format_platforms(unknown),
-            _format_platforms(_PLATFORMS.keys()),
-        ))
-
-def _check_matching_platforms(values, attr_name, what, platforms):
-    keys = sorted(values.keys())
-    expected = sorted(platforms)
-    if keys != expected:
-        fail("{} must use the same platforms as {}_urls for {}: got [{}], expected [{}].".format(
-            attr_name,
-            what,
-            what,
-            _format_platforms(keys),
-            _format_platforms(expected),
-        ))
+_PLATFORMS = ANDROID_PLATFORMS
 
 def _custom_platform_archives(rctx, urls, sha256s, strip_prefixes, what):
     if not urls or not sha256s:
@@ -133,11 +69,11 @@ def _custom_platform_archives(rctx, urls, sha256s, strip_prefixes, what):
             what,
             what,
         ))
-    _check_known_platforms(urls, "{}_urls".format(what), what)
+    _check_known_platforms(urls, "{}_urls".format(what), _PLATFORMS.keys(), what = what)
     platforms = sorted(urls.keys())
-    _check_matching_platforms(sha256s, "{}_sha256s".format(what), what, platforms)
+    _check_matching_platforms(sha256s, "{}_sha256s".format(what), platforms, what = what)
     if strip_prefixes:
-        _check_matching_platforms(strip_prefixes, "{}_strip_prefixes".format(what), what, platforms)
+        _check_matching_platforms(strip_prefixes, "{}_strip_prefixes".format(what), platforms, what = what)
     return urls, sha256s, strip_prefixes, platforms
 
 def _custom_archive_attrs(rctx):
@@ -178,11 +114,11 @@ def _resolve_known_sdk(rctx, data, known):
         fail("Unknown platform-tools version {} in SDK versions metadata.".format(repr(platform_tools_version)))
 
     build_tools = components["build_tools"][build_tools_version]
-    build_tools_urls, build_tools_sha256s, build_tools_strip_prefixes = _archive_attrs(build_tools["archives"])
+    build_tools_urls, build_tools_sha256s, build_tools_strip_prefixes = _archive_attrs(build_tools["archives"], include_strip_prefixes = True)
     build_tools_platforms = sorted(build_tools_urls.keys())
 
     platform_tools = components["platform_tools"][platform_tools_version]
-    platform_tools_urls, platform_tools_sha256s, platform_tools_strip_prefixes = _archive_attrs(platform_tools["archives"])
+    platform_tools_urls, platform_tools_sha256s, platform_tools_strip_prefixes = _archive_attrs(platform_tools["archives"], include_strip_prefixes = True)
     platform_tools_platforms = sorted(platform_tools_urls.keys())
 
     platform = known["platform"]
@@ -296,6 +232,8 @@ def _runner_script_content(rctx, name, platform, build_tools_directory, executab
     tool = "{}{}".format(name, executable_extension)
     tool_path = "build-tools/{}/{}/{}".format(platform, build_tools_directory, tool)
     libs = "build-tools/{}/{}".format(platform, build_tools_directory)
+
+    # buildifier: disable=external-path
     return """#!/usr/bin/env bash
 set -eu
 repo="${{RUNFILES_DIR:-${{0}}.runfiles}}/{repo_name}"
@@ -505,39 +443,15 @@ def _adb_alias_label(platform):
         return "platform-tools/windows/adb.exe"
     return "platform-tools/{}/adb".format(platform)
 
-def _select_alias(name, entries):
-    lines = [
-        "alias(",
-        "    name = \"{}\",".format(name),
-        "    actual = select({",
-    ]
-    for condition, actual in entries:
-        lines.append("        \"{}\": \"{}\",".format(condition, actual))
-    lines.extend([
-        "    }),",
-        "    tags = [\"manual\"],",
-        ")",
-    ])
-    return "\n".join(lines)
-
 def _platform_select_alias(name, platforms, linux, darwin, windows):
     entries = []
     if "linux" in platforms:
-        entries.append((":linux_x86_64_exec", linux))
+        entries.append((_platform_condition("linux"), linux))
     if "darwin" in platforms:
-        entries.append((":darwin_exec", darwin))
+        entries.append((_platform_condition("darwin"), darwin))
     if "windows" in platforms:
-        entries.append((":windows_x86_64_exec", windows))
-    return _select_alias(name, entries)
-
-def _platform_condition(platform):
-    if platform == "linux":
-        return ":linux_x86_64_exec"
-    if platform == "darwin":
-        return ":darwin_exec"
-    if platform == "windows":
-        return ":windows_x86_64_exec"
-    fail("Unsupported platform {}.".format(repr(platform)))
+        entries.append((_platform_condition("windows"), windows))
+    return _select_alias(name, entries, tags = ["manual"])
 
 def _platform_aliases(sdk):
     platforms = sdk["platforms"]
@@ -652,25 +566,11 @@ def _local_sdk_path_rule():
     srcs = ["."],
 )"""
 
-def _external_label(repository, target):
-    return "@{}//:{}".format(repository, target)
-
-def _platform_repository(rctx, platform):
-    if platform not in rctx.attr.platform_repositories:
-        fail("Missing platform repository for Android SDK platform {}. Got [{}].".format(
-            repr(platform),
-            _format_platforms(rctx.attr.platform_repositories.keys()),
-        ))
-    return rctx.attr.platform_repositories[platform]
-
-def _facade_label(rctx, platform, target):
-    return _external_label(_platform_repository(rctx, platform), target)
-
 def _facade_select_alias(rctx, sdk, name, target):
     return _select_alias(name, [
-        (_platform_condition(platform), _facade_label(rctx, platform, target))
+        (_platform_condition(platform), _external_label(_platform_repository(rctx, platform, "SDK"), target))
         for platform in sdk["platforms"]
-    ])
+    ], tags = ["manual"])
 
 def _facade_platform_aliases(rctx, sdk):
     blocks = [
@@ -689,7 +589,7 @@ def _facade_platform_aliases(rctx, sdk):
     return "\n\n".join(blocks)
 
 def _facade_platform_rules_for(rctx, platform, sdk):
-    repository = _platform_repository(rctx, platform)
+    repository = _platform_repository(rctx, platform, "SDK")
     sdk_name = "sdk_{}".format(platform)
     build_tools_version = sdk["build_tools_version"]
     blocks = []
@@ -791,7 +691,7 @@ def _hermetic_android_sdk_platform_repository_impl(rctx):
     if not rctx.attr.build_tools_version:
         fail("hermetic_android_sdk_platform_repository requires build_tools_version.")
 
-    _require_license(rctx)
+    _require_license(rctx, ANDROID_SDK_LICENSE_ENV, "SDK")
     sdk = _sdk_for_platform(_resolve_sdk(rctx), rctx.attr.platform)
     _download_sdk(rctx, sdk)
     _write_runner_scripts(rctx, sdk)
@@ -834,7 +734,7 @@ hermetic_android_sdk_platform_repository = repository_rule(
         "platforms_sha256": attr.string(),
         "platforms_strip_prefix": attr.string(),
         "platforms_url": attr.string(),
-        "platform": attr.string(mandatory = True, values = SDK_PLATFORMS),
+        "platform": attr.string(mandatory = True, values = sorted(_PLATFORMS.keys())),
         "version": attr.string(mandatory = True),
         "_versions_json": attr.label(
             default = SDK_VERSIONS,
@@ -850,7 +750,7 @@ def _hermetic_android_sdk_repository_impl(rctx):
     if not rctx.attr.build_tools_version:
         fail("hermetic_android_sdk_repository requires build_tools_version.")
 
-    _require_license(rctx)
+    _require_license(rctx, ANDROID_SDK_LICENSE_ENV, "SDK")
     sdk = _resolve_sdk(rctx)
     _download_component(
         rctx,

--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -69,7 +69,7 @@ def _custom_platform_archives(rctx, urls, sha256s, strip_prefixes, what):
             what,
             what,
         ))
-    _check_known_platforms(urls, "{}_urls".format(what), _PLATFORMS.keys(), what = what)
+    _check_known_platforms(urls, "{}_urls".format(what), what = what)
     platforms = sorted(urls.keys())
     _check_matching_platforms(sha256s, "{}_sha256s".format(what), platforms, what = what)
     if strip_prefixes:

--- a/tests/action_command_line_test.bzl
+++ b/tests/action_command_line_test.bzl
@@ -85,6 +85,7 @@ action_command_line_test = analysistest.make(
         "not_expected_argv": attr.string_list(),
     },
     config_settings = {
+        # buildifier: disable=canonical-repository
         "//command_line_option:platforms": "@@rules_android+//:x86_64",
     },
 )


### PR DESCRIPTION
Breaking things into platform specific repos so that the top-level repo isn't downloading all platforms even if they aren't needed on a single host platform.