### PR TITLE
Remove separate api_level from versions.json

### DIFF
--- a/sdk/repositories.bzl
+++ b/sdk/repositories.bzl
@@ -98,9 +98,9 @@ def _common_platforms(*platform_groups):
         ))
     return platforms
 
-def _resolve_known_sdk(rctx, data, known):
+def _resolve_known_sdk(rctx, data, version, known):
     components = data["components"]
-    api_level = rctx.attr.api_level or known["api_level"]
+    api_level = rctx.attr.api_level or version
     build_tools_version = rctx.attr.build_tools_version
 
     if build_tools_version not in components["build_tools"]:
@@ -185,7 +185,7 @@ def _resolve_sdk(rctx):
     if rctx.attr.version in versions:
         if _custom_archive_attrs(rctx):
             return _resolve_custom_sdk(rctx)
-        return _resolve_known_sdk(rctx, versions_json, versions[rctx.attr.version])
+        return _resolve_known_sdk(rctx, versions_json, rctx.attr.version, versions[rctx.attr.version])
     return _resolve_custom_sdk(rctx)
 
 def _download_component(rctx, url, sha256, output, strip_prefix = ""):

--- a/sdk/versions.json
+++ b/sdk/versions.json
@@ -106,7 +106,6 @@
   },
   "versions": {
     "24": {
-      "api_level": "24",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-24_r02.zip",
@@ -114,7 +113,6 @@
       }
     },
     "25": {
-      "api_level": "25",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-25_r03.zip",
@@ -122,7 +120,6 @@
       }
     },
     "26": {
-      "api_level": "26",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-26_r02.zip",
@@ -130,7 +127,6 @@
       }
     },
     "27": {
-      "api_level": "27",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-27_r03.zip",
@@ -138,7 +134,6 @@
       }
     },
     "28": {
-      "api_level": "28",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-28_r06.zip",
@@ -146,7 +141,6 @@
       }
     },
     "29": {
-      "api_level": "29",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-29_r05.zip",
@@ -154,7 +148,6 @@
       }
     },
     "30": {
-      "api_level": "30",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-30_r03.zip",
@@ -162,7 +155,6 @@
       }
     },
     "31": {
-      "api_level": "31",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-31_r01.zip",
@@ -170,7 +162,6 @@
       }
     },
     "32": {
-      "api_level": "32",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-32_r01.zip",
@@ -178,7 +169,6 @@
       }
     },
     "33": {
-      "api_level": "33",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-33-ext3_r03.zip",
@@ -186,7 +176,6 @@
       }
     },
     "34": {
-      "api_level": "34",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-34-ext7_r03.zip",
@@ -194,7 +183,6 @@
       }
     },
     "35": {
-      "api_level": "35",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-35_r02.zip",
@@ -202,7 +190,6 @@
       }
     },
     "36": {
-      "api_level": "36",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-36_r02.zip",
@@ -210,7 +197,6 @@
       }
     },
     "36.1": {
-      "api_level": "36.1",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-36.1_r01.zip",
@@ -218,7 +204,6 @@
       }
     },
     "37.0": {
-      "api_level": "37.0",
       "platform_tools_version": "37.0.0",
       "platform": {
         "file": "platform-37.0_r02.zip",

--- a/tools/generate_sdk_versions.py
+++ b/tools/generate_sdk_versions.py
@@ -244,7 +244,6 @@ def _generate():
     versions = {}
     for version, pkg in platforms.items():
         versions[version] = {
-            "api_level": version,
             "platform_tools_version": platform_tools_version,
             "platform": _archive_json(_single_archive(pkg), metadata, infer_prefix=False),
         }


### PR DESCRIPTION
This was always the same as the key
