### PR TITLE
Fix ndk redirecting to libraries

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "platform_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+)
+
+config_setting(
+    name = "platform_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/examples/basic_app/java/com/example/hermetic/BUILD.bazel
+++ b/examples/basic_app/java/com/example/hermetic/BUILD.bazel
@@ -35,6 +35,10 @@ cc_library(
     hdrs = ["jni_dep.h"],
     linkopts = ["-llog"],
     tags = ["manual"],
+    deps = [
+        "@androidndk//:cpufeatures",
+        "@androidndk//:native_app_glue",
+    ],
 )
 
 build_test(

--- a/examples/basic_app/java/com/example/hermetic/jni_dep.cc
+++ b/examples/basic_app/java/com/example/hermetic/jni_dep.cc
@@ -1,5 +1,11 @@
 #include "jni_dep.h"
 
+#include "sources/android/cpufeatures/cpu-features.h"
+#include "sources/android/native_app_glue/android_native_app_glue.h"
+
 int add_from_dep(int left, int right) {
+  static_cast<void>(android_getCpuCount);
+  static_cast<void>(app_dummy);
+
   return left + right;
 }

--- a/ndk/BUILD.bazel
+++ b/ndk/BUILD.bazel
@@ -1,4 +1,10 @@
 exports_files([
     "BUILD.androidndk.bazel",
+    "BUILD.ndkredirect.bazel",
     "versions.json",
 ])
+
+toolchain_type(
+    name = "exports_toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/ndk/BUILD.ndkredirect.bazel
+++ b/ndk/BUILD.ndkredirect.bazel
@@ -1,0 +1,65 @@
+"""Generated Android NDK platform redirect repository."""
+
+load("@hermetic_android_toolchains//ndk:exports.bzl", "ndk_cc_export", "ndk_exports_toolchain", "ndk_file_export")
+load("@hermetic_android_toolchains//private:utils.bzl", "ANDROID_PLATFORMS")
+load("//:target_systems.bzl", "CPU_CONSTRAINT", "TARGET_SYSTEM_NAMES")
+
+package(default_visibility = ["//visibility:public"])
+
+[
+    toolchain(
+        name = "toolchain_{}_{}".format(platform_name, target_system_name),
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = [
+            "@platforms//os:android",
+            CPU_CONSTRAINT[target_system_name],
+        ],
+        toolchain = "@androidndk_{}//toolchains/llvm/prebuilt/{}-x86_64:cc_toolchain_{}".format(
+            platform,
+            platform,
+            target_system_name,
+        ),
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
+    for platform in sorted(ANDROID_PLATFORMS.keys())
+    for platform_name, exec_compatible_with in ANDROID_PLATFORMS[platform]["constraints"]
+    for target_system_name in TARGET_SYSTEM_NAMES
+]
+
+[
+    ndk_exports_toolchain(
+        name = "exports_{}".format(platform_name),
+        android_native_app_glue_header = "@androidndk_{}//:sources/android/native_app_glue/android_native_app_glue.h".format(platform),
+        cpufeatures = "@androidndk_{}//:cpufeatures".format(platform),
+        native_app_glue = "@androidndk_{}//:native_app_glue".format(platform),
+    )
+    for platform in sorted(ANDROID_PLATFORMS.keys())
+    for platform_name, _ in ANDROID_PLATFORMS[platform]["constraints"]
+]
+
+[
+    toolchain(
+        name = "exports_toolchain_{}".format(platform_name),
+        exec_compatible_with = exec_compatible_with,
+        target_compatible_with = ["@platforms//os:android"],
+        toolchain = ":exports_{}".format(platform_name),
+        toolchain_type = "@hermetic_android_toolchains//ndk:exports_toolchain_type",
+    )
+    for platform in sorted(ANDROID_PLATFORMS.keys())
+    for platform_name, exec_compatible_with in ANDROID_PLATFORMS[platform]["constraints"]
+]
+
+ndk_cc_export(
+    name = "cpufeatures",
+    export = "cpufeatures",
+)
+
+ndk_cc_export(
+    name = "native_app_glue",
+    export = "native_app_glue",
+)
+
+ndk_file_export(
+    name = "sources/android/native_app_glue/android_native_app_glue.h",
+    export = "android_native_app_glue_header",
+)

--- a/ndk/BUILD.ndkredirect.bazel
+++ b/ndk/BUILD.ndkredirect.bazel
@@ -32,6 +32,7 @@ package(default_visibility = ["//visibility:public"])
         android_native_app_glue_header = "@androidndk_{}//:sources/android/native_app_glue/android_native_app_glue.h".format(platform),
         cpufeatures = "@androidndk_{}//:cpufeatures".format(platform),
         native_app_glue = "@androidndk_{}//:native_app_glue".format(platform),
+        tags = ["manual"],
     )
     for platform in sorted(ANDROID_PLATFORMS.keys())
     for platform_name, _ in ANDROID_PLATFORMS[platform]["constraints"]
@@ -52,14 +53,17 @@ package(default_visibility = ["//visibility:public"])
 ndk_cc_export(
     name = "cpufeatures",
     export = "cpufeatures",
+    tags = ["manual"],
 )
 
 ndk_cc_export(
     name = "native_app_glue",
     export = "native_app_glue",
+    tags = ["manual"],
 )
 
 ndk_file_export(
     name = "sources/android/native_app_glue/android_native_app_glue.h",
     export = "android_native_app_glue_header",
+    tags = ["manual"],
 )

--- a/ndk/exports.bzl
+++ b/ndk/exports.bzl
@@ -1,0 +1,67 @@
+"""Rules for exposing Android NDK source exports."""
+
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+_EXPORTS_TOOLCHAIN_TYPE = Label("//ndk:exports_toolchain_type")
+
+def _ndk_exports_toolchain_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        cc_exports = {
+            "cpufeatures": ctx.attr.cpufeatures[CcInfo],
+            "native_app_glue": ctx.attr.native_app_glue[CcInfo],
+        },
+        file_exports = {
+            "android_native_app_glue_header": ctx.file.android_native_app_glue_header,
+        },
+    )]
+
+ndk_exports_toolchain = rule(
+    implementation = _ndk_exports_toolchain_impl,
+    attrs = {
+        "android_native_app_glue_header": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "cpufeatures": attr.label(
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+        "native_app_glue": attr.label(
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+    },
+)
+
+def _ndk_cc_export_impl(ctx):
+    toolchain = ctx.toolchains[_EXPORTS_TOOLCHAIN_TYPE]
+    return [toolchain.cc_exports[ctx.attr.export]]
+
+ndk_cc_export = rule(
+    implementation = _ndk_cc_export_impl,
+    attrs = {
+        "export": attr.string(
+            mandatory = True,
+            values = [
+                "cpufeatures",
+                "native_app_glue",
+            ],
+        ),
+    },
+    toolchains = [_EXPORTS_TOOLCHAIN_TYPE],
+)
+
+def _ndk_file_export_impl(ctx):
+    toolchain = ctx.toolchains[_EXPORTS_TOOLCHAIN_TYPE]
+    return [DefaultInfo(files = depset([toolchain.file_exports[ctx.attr.export]]))]
+
+ndk_file_export = rule(
+    implementation = _ndk_file_export_impl,
+    attrs = {
+        "export": attr.string(
+            mandatory = True,
+            values = ["android_native_app_glue_header"],
+        ),
+    },
+    toolchains = [_EXPORTS_TOOLCHAIN_TYPE],
+)

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -233,7 +233,6 @@ def _hermetic_android_ndk_repository_impl(rctx):
         fail("hermetic_android_ndk_repository requires version.")
 
     require_license(rctx, ANDROID_NDK_LICENSE_ENV, "NDK")
-    ndk = _resolve_ndk(rctx)
 
     rctx.symlink(Label("//ndk:BUILD.ndkredirect.bazel"), "BUILD.bazel")
     rctx.template(

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -6,12 +6,8 @@ load(
     "archive_url",
     "check_known_platforms",
     "check_matching_platforms",
-    "external_label",
     "format_platforms",
-    "platform_condition",
-    "platform_repository",
     "require_license",
-    "select_alias",
 )
 
 ANDROID_NDK_LICENSE_ENV = "ACCEPTED_ANDROID_NDK_LICENSE_VERSION"
@@ -139,14 +135,6 @@ def _clang_resource_dir(rctx, clang_directory):
         return "{}/{}".format(parent, versions[0])
     fail("Could not find clang resource directory under {}.".format(clang_directory))
 
-def _platform_toolchains(platforms):
-    toolchains = []
-    for platform in platforms:
-        clang_directory = _PLATFORMS[platform]["clang_directory"]
-        for name, constraints in _PLATFORMS[platform]["constraints"]:
-            toolchains.append((name, clang_directory, constraints))
-    return repr(toolchains)
-
 def _ndk_for_platform(ndk, platform):
     if platform not in ndk["platforms"]:
         fail("Android NDK archives are not available for platform {}. Available platforms: [{}].".format(
@@ -156,66 +144,6 @@ def _ndk_for_platform(ndk, platform):
     platform_ndk = dict(ndk)
     platform_ndk["platforms"] = [platform]
     return platform_ndk
-
-def _platform_redirect_alias(rctx, ndk, name, target):
-    return select_alias(name, [
-        (platform_condition(platform), external_label(platform_repository(rctx, platform, "NDK"), target))
-        for platform in ndk["platforms"]
-    ])
-
-def _platform_redirect_toolchains(rctx, ndk):
-    toolchains = []
-    for platform in ndk["platforms"]:
-        repository = platform_repository(rctx, platform, "NDK")
-        clang_directory = _PLATFORMS[platform]["clang_directory"]
-        toolchain_pattern = "@{}//{}:cc_toolchain_{{}}".format(repository, clang_directory)
-        for name, constraints in _PLATFORMS[platform]["constraints"]:
-            toolchains.append((name, toolchain_pattern, constraints))
-    return repr(toolchains)
-
-def _platform_redirect_toolchain_suite_alias(rctx, ndk):
-    return select_alias("toolchain", [
-        (
-            platform_condition(platform),
-            "@{}//{}:cc_toolchain_suite".format(
-                platform_repository(rctx, platform, "NDK"),
-                _PLATFORMS[platform]["clang_directory"],
-            ),
-        )
-        for platform in ndk["platforms"]
-    ])
-
-def _platform_redirect_build_file_content(rctx, ndk):
-    aliases = [
-        _platform_redirect_toolchain_suite_alias(rctx, ndk),
-        _platform_redirect_alias(rctx, ndk, "cpufeatures", "cpufeatures"),
-        _platform_redirect_alias(rctx, ndk, "native_app_glue", "native_app_glue"),
-        _platform_redirect_alias(rctx, ndk, "sources/android/native_app_glue/android_native_app_glue.h", "sources/android/native_app_glue/android_native_app_glue.h"),
-    ]
-    return """\"\"\"Generated Android NDK platform redirect repository.\"\"\"
-
-load("//:platform_toolchains.bzl", "PLATFORM_TOOLCHAINS")
-load("//:target_systems.bzl", "CPU_CONSTRAINT", "TARGET_SYSTEM_NAMES")
-
-package(default_visibility = ["//visibility:public"])
-
-[
-    toolchain(
-        name = "toolchain_{{}}_{{}}".format(platform_name, target_system_name),
-        exec_compatible_with = exec_compatible_with,
-        target_compatible_with = [
-            "@platforms//os:android",
-            CPU_CONSTRAINT[target_system_name],
-        ],
-        toolchain = toolchain_pattern.format(target_system_name),
-        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-    )
-    for platform_name, toolchain_pattern, exec_compatible_with in PLATFORM_TOOLCHAINS
-    for target_system_name in TARGET_SYSTEM_NAMES
-]
-
-{aliases}
-""".format(aliases = "\n\n".join(aliases))
 
 def _generate_platform_build_files(rctx, ndk):
     repository_name = rctx.attr._rules_android_ndk_build.workspace_name
@@ -255,10 +183,6 @@ def _hermetic_android_ndk_platform_repository_impl(rctx):
 
     rctx.file("ndk/.keep", "")
     rctx.symlink(rctx.path("sources"), "ndk/sources")
-    rctx.file(
-        "platform_toolchains.bzl",
-        "PLATFORM_TOOLCHAINS = {}\n".format(_platform_toolchains(ndk["platforms"])),
-    )
     rctx.symlink(Label("//ndk:BUILD.androidndk.bazel"), "BUILD.bazel")
     rctx.template(
         "target_systems.bzl",
@@ -311,11 +235,7 @@ def _hermetic_android_ndk_repository_impl(rctx):
     require_license(rctx, ANDROID_NDK_LICENSE_ENV, "NDK")
     ndk = _resolve_ndk(rctx)
 
-    rctx.file(
-        "platform_toolchains.bzl",
-        "PLATFORM_TOOLCHAINS = {}\n".format(_platform_redirect_toolchains(rctx, ndk)),
-    )
-    rctx.file("BUILD.bazel", _platform_redirect_build_file_content(rctx, ndk))
+    rctx.symlink(Label("//ndk:BUILD.ndkredirect.bazel"), "BUILD.bazel")
     rctx.template(
         "target_systems.bzl",
         rctx.attr._template_target_systems,

--- a/private/utils.bzl
+++ b/private/utils.bzl
@@ -22,9 +22,9 @@ ANDROID_PLATFORMS = {
 }
 
 _PLATFORM_CONDITIONS = {
-    "darwin": ":darwin_exec",
-    "linux": ":linux_x86_64_exec",
-    "windows": ":windows_x86_64_exec",
+    "darwin": Label("//:platform_darwin"),
+    "linux": Label("//:platform_linux"),
+    "windows": Label("//:platform_windows"),
 }
 
 def require_license(rctx, license_env, component):

--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -32,32 +32,6 @@ config_setting(
 )
 
 config_setting(
-    name = "linux_x86_64_exec",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "darwin_exec",
-    constraint_values = [
-        "@platforms//os:macos",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "windows_x86_64_exec",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_64",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
     name = "api_%{api_level}_enabled",
     flag_values = {
         ":api_level": "%{api_level}",
@@ -150,7 +124,7 @@ sh_binary(
 alias(
     name = "fail",
     actual = select({
-        ":windows_x86_64_exec": ":windows_fail.cmd",
+        "@platforms//os:windows": ":windows_fail.cmd",
         "//conditions:default": ":bash_fail",
     }),
 )


### PR DESCRIPTION
Previously we were doing a select() to determine which cc_library to
direct to, but that select was around host platform not target platform.
We have to use toolchain resolution for that instead
