### PR TITLE
Remove sdk_path filegroup

### DIFF
--- a/sdk/BUILD.androidsdk.tpl
+++ b/sdk/BUILD.androidsdk.tpl
@@ -200,8 +200,3 @@ filegroup(
         "platforms/android-%{api_level}/framework.aidl",
     ],
 )
-
-filegroup(
-    name = "sdk_path",
-    srcs = ["."],
-)


### PR DESCRIPTION
This doesn't seem to be used by the android rules and causes bazel
errors if you attempt to "build" it
