### PR TITLE
Include something through ndk/sources

### DIFF
--- a/examples/basic_app/java/com/example/hermetic/jni_dep.cc
+++ b/examples/basic_app/java/com/example/hermetic/jni_dep.cc
@@ -1,6 +1,6 @@
 #include "jni_dep.h"
 
-#include "sources/android/cpufeatures/cpu-features.h"
+#include "ndk/sources/android/cpufeatures/cpu-features.h"
 #include "sources/android/native_app_glue/android_native_app_glue.h"
 
 int add_from_dep(int left, int right) {

--- a/ndk/BUILD.androidndk.bazel
+++ b/ndk/BUILD.androidndk.bazel
@@ -13,10 +13,7 @@ exports_files([
 
 cc_library(
     name = "cpufeatures",
-    srcs = glob([
-        "ndk/sources/android/cpufeatures/*.c",
-        "sources/android/cpufeatures/*.c",
-    ]),
+    srcs = glob(["sources/android/cpufeatures/*.c"]),
     hdrs = glob([
         "ndk/sources/android/cpufeatures/*.h",
         "sources/android/cpufeatures/*.h",
@@ -28,10 +25,7 @@ cc_library(
 # https://developer.android.com/games/agdk/game-activity
 cc_library(
     name = "native_app_glue",
-    srcs = glob([
-        "ndk/sources/android/native_app_glue/*.c",
-        "sources/android/native_app_glue/*.c",
-    ]),
+    srcs = glob(["sources/android/native_app_glue/*.c"]),
     hdrs = glob([
         "ndk/sources/android/native_app_glue/*.h",
         "sources/android/native_app_glue/*.h",


### PR DESCRIPTION
This is kept for backwards compat for headers, but we don't want to
compile the source files twice.
