### PR TITLE
Add CI step to check MODULE.bazel.lock is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,17 @@ jobs:
         shell: bash
         run: bazel test --config=buildbuddy-ci ${BUILDBUDDY_API_KEY:+--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY} //...
 
+      - name: Verify MODULE.bazel.lock is unchanged
+        if: always()
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain -- MODULE.bazel.lock)" ]]; then
+            git diff -- MODULE.bazel.lock
+            git diff --cached -- MODULE.bazel.lock
+            echo "::error file=MODULE.bazel.lock::MODULE.bazel.lock changed during CI. Run Bazel locally and commit the updated lockfile."
+            exit 1
+          fi
+
   bazel_latest:
     name: Bazel latest (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This also makes sure we don't introduce platform specific churn in our
own extensions
