### PR TITLE
Use git-archive for release tar

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ jobs:
           set -euo pipefail
           archive="hermetic_android_toolchains.$TAG.tar.gz"
 
-          COPYFILE_DISABLE=1 tar czvf "$archive" ./*
+          git archive --format=tar.gz --output "$archive" HEAD
           gh api repos/${{ github.repository }}/releases/generate-notes -f tag_name="$TAG" -f target_commitish="$GITHUB_REF_NAME" --jq .body > notes.md
           ./.github/generate-notes.sh "$TAG" "$archive" >> notes.md
           gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$archive"


### PR DESCRIPTION
Nicer in general but also includes the root dotfiles like .bazelrc which
is necessary for BCR testing
