### PR TITLE
Update README for rules_android_ndk override_repo

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -7,11 +7,12 @@ readonly new_version=$1
 cat <<EOF
 ### MODULE.bazel Snippet
 
-\`\`\`bzl
-bazel_dep(name = "hermetic_android_toolchains", version = "$new_version")
-bazel_dep(name = "rules_android", version = "0.7.3")
+\`\`\`starlark
+bazel_dep(name = "hermetic_android_toolchains", version = "$new_version", dev_dependency = True)
+bazel_dep(name = "rules_android", version = "0.7.3", dev_dependency = True)
+bazel_dep(name = "rules_android_ndk", version = "0.1.5", dev_dependency = True)
 
-android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android")
+android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
 android.sdk(
     build_tools_version = "37.0.0",
     version = "37.0",
@@ -20,10 +21,16 @@ android.ndk(version = "r29")
 use_repo(android, "androidsdk", "androidndk")
 
 # Make @rules_android's @androidsdk labels resolve to the hermetic SDK.
-rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
+rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension", dev_dependency = True)
+
 override_repo(rules_android_sdk, "androidsdk")
 
-register_toolchains("@androidndk//:all", "@androidsdk//:all")
+# Make @rules_android_ndk's @androidndk labels resolve to the hermetic SDK.
+rules_android_ndk = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension", dev_dependency = True)
+
+override_repo(rules_android_ndk, "androidndk")
+
+register_toolchains("@androidndk//:all", "@androidsdk//:all", dev_dependency = True)
 \`\`\`
 
 Setup docs: https://github.com/keith/hermetic_android_toolchains#usage

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,6 +56,15 @@ rules_android_sdk = use_extension(
 
 override_repo(rules_android_sdk, "androidsdk")
 
+# Make @rules_android_ndk's @androidndk labels resolve to the hermetic SDK.
+rules_android_ndk = use_extension(
+    "@rules_android_ndk//:extension.bzl",
+    "android_ndk_repository_extension",
+    dev_dependency = True,
+)
+
+override_repo(rules_android_ndk, "androidndk")
+
 register_toolchains(
     "@androidndk//:all",
     "@androidsdk//:all",

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ developers and CI.
 Add this to your `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "hermetic_android_toolchains", version = "0.0.0")
-bazel_dep(name = "rules_android", version = "0.7.3")
+bazel_dep(name = "hermetic_android_toolchains", version = "0.0.0", dev_dependency = True)
+bazel_dep(name = "rules_android", version = "0.7.3", dev_dependency = True)
+bazel_dep(name = "rules_android_ndk", version = "0.1.5", dev_dependency = True)
 
-android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android")
+android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
 android.sdk(
     build_tools_version = "37.0.0",
     version = "37.0",
@@ -23,10 +24,16 @@ android.ndk(version = "r29")
 use_repo(android, "androidsdk", "androidndk")
 
 # Make @rules_android's @androidsdk labels resolve to the hermetic SDK.
-rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
+rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension", dev_dependency = True)
+
 override_repo(rules_android_sdk, "androidsdk")
 
-register_toolchains("@androidndk//:all", "@androidsdk//:all")
+# Make @rules_android_ndk's @androidndk labels resolve to the hermetic SDK.
+rules_android_ndk = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension", dev_dependency = True)
+
+override_repo(rules_android_ndk, "androidndk")
+
+register_toolchains("@androidndk//:all", "@androidsdk//:all", dev_dependency = True)
 ```
 
 Once you have reviewed and accepted the SDK and NDK licenses, add this


### PR DESCRIPTION
You shouldn't call this but if one of your transitive deps does, you
need to override it. As far as I can tell it doesn't hurt to call that
even if it isn't called in the dep tree.
