### PR TITLE
ndk: expose libc++_shared.so and source.properties as labels

### DIFF
--- a/ndk/BUILD.androidndk.bazel
+++ b/ndk/BUILD.androidndk.bazel
@@ -9,6 +9,11 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "target_systems.bzl",
     "sources/android/native_app_glue/android_native_app_glue.h",
+    # The NDK's version manifest sits at the repo root. A non-cc-toolchain
+    # consumer (e.g. a Swift cross-compile toolchain that needs the sysroot
+    # *path*, not just a registered cc toolchain) can resolve this file and take
+    # its dirname to locate the NDK root and the per-host sysroot directory.
+    "source.properties",
 ])
 
 cc_library(

--- a/ndk/BUILD.ndk_sysroot.tpl
+++ b/ndk/BUILD.ndk_sysroot.tpl
@@ -1,0 +1,87 @@
+"""Declarations for the NDK's Clang sysroot directory.
+
+Mirrors rules_android_ndk's BUILD.ndk_sysroot.tpl and adds a `libcxx_shared_*`
+target. The upstream template exposes only the static C++ runtime libraries
+(`static_runtime_lib_*`); the shared `libc++_shared.so` is reachable only through
+the coarse `all_files`. Non-cc-toolchain consumers (e.g. a Swift cross-compile
+toolchain that produces a JNI `.so`) need to bundle exactly that file into an
+APK, so expose it as its own target.
+"""
+
+load("//:target_systems.bzl", "TARGET_SYSTEM_NAMES")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+
+[filegroup(
+    name = "libc_top_%s" % target_system_name,
+    srcs = glob(
+        [
+            "usr/lib/{target_system_name}/{api_level}/*".format(
+                target_system_name = target_system_name,
+            ),
+        ],
+        allow_empty = True,
+    ),
+) for target_system_name in TARGET_SYSTEM_NAMES]
+
+[filegroup(
+    name = "dynamic_runtime_lib_%s" % target_system_name,
+    srcs = glob(
+        [
+            # "usr/lib/%s/**/*.so" % target_system_name,
+            # "usr/lib/%s/**/*.a" % target_system_name,
+        ],
+        allow_empty = True,
+    ),
+) for target_system_name in TARGET_SYSTEM_NAMES]
+
+[filegroup(
+    name = "static_runtime_lib_%s" % target_system_name,
+    srcs = [
+        "usr/lib/%s/libc++_static.a" % target_system_name,
+        "usr/lib/%s/libc++abi.a" % target_system_name,
+    ] + {
+        # libandroid_support was removed in NDK 26, so use a glob
+        # for backward compatibility.
+        "arm-linux-androideabi": glob(
+            [
+                "usr/lib/arm-linux-androideabi/libandroid_support.a",
+            ],
+            allow_empty = True,
+        ),
+        "i686-linux-android": glob(
+            [
+                "usr/lib/i686-linux-android/libandroid_support.a",
+            ],
+            allow_empty = True,
+        ),
+    }.get(
+        target_system_name,
+        [],
+    ),
+) for target_system_name in TARGET_SYSTEM_NAMES]
+
+# The shared C++ runtime. An app that links NDK/C++ code (including Swift code
+# cross-compiled for Android) must package this `.so` into its APK.
+[filegroup(
+    name = "libcxx_shared_%s" % target_system_name,
+    srcs = glob(
+        [
+            "usr/lib/%s/libc++_shared.so" % target_system_name,
+        ],
+        allow_empty = True,
+    ),
+) for target_system_name in TARGET_SYSTEM_NAMES]
+
+filegroup(
+    name = "sysroot_includes",
+    srcs = glob([
+        "**/include/**/*",
+    ]),
+)

--- a/ndk/repositories.bzl
+++ b/ndk/repositories.bzl
@@ -213,7 +213,10 @@ hermetic_android_ndk_platform_repository = repository_rule(
             allow_single_file = True,
         ),
         "_template_ndk_sysroot": attr.label(
-            default = Label("@rules_android_ndk//:BUILD.ndk_sysroot.tpl"),
+            # Our own copy of rules_android_ndk's template, extended with a
+            # `libcxx_shared_*` target so non-cc-toolchain consumers (e.g. a
+            # Swift cross-compile toolchain) can package the shared C++ runtime.
+            default = Label("//ndk:BUILD.ndk_sysroot.tpl"),
             allow_single_file = True,
         ),
         "_template_target_systems": attr.label(


### PR DESCRIPTION
## Expose the NDK sysroot's `libc++_shared.so` and `source.properties` as labels

### Why

`@androidndk` is great for **C/C++** consumers: you register `@androidndk//:all`
and the legacy crosstool `cc_toolchain` is host-resolved through toolchain
resolution. But a consumer that is **not** a `cc_*` rule can't go through that
path. The motivating case is a Swift -> Android cross-compilation toolchain
(rules_swift): `swiftc` needs the NDK **sysroot path** directly at compile time
(`swiftc -sdk <sysroot>`) so its built-in clang importer can find the Android
system headers, and the resulting JNI `.so` needs the NDK's
**`libc++_shared.so`** packaged into the APK (Swift links the C++ runtime).

Today neither of those is reachable as a label:

- `libc++_shared.so` lives in the sysroot subpackage but the generated sysroot
  `BUILD` (from rules_android_ndk's `BUILD.ndk_sysroot.tpl`) only exposes the
  *static* runtime libs (`static_runtime_lib_*`); the shared library is reachable
  only through the coarse `all_files` glob, with no clean target.
- `source.properties` (the NDK version manifest at the repo root) isn't exported,
  so a consumer can't resolve it to discover the NDK root / per-host sysroot
  directory.

Host resolution stays on the **consumer** side: you can't host-select a plain
file label out of `@androidndk` via `select()` (a `select()` resolves against the
*target* platform, not the exec/host), so a consumer that needs a host artifact
resolves the per-host `@androidndk_<host>` repo itself at repo-rule time. These
two small additions are all it needs.

### What

1. **`ndk/BUILD.ndk_sysroot.tpl`** - a hermetic-owned copy of rules_android_ndk's
   sysroot template, extended with a `libcxx_shared_<target_system>` filegroup per
   Android target triple (pointing at `usr/lib/<triple>/libc++_shared.so`). The
   per-host repo rule now renders this template instead of
   `@rules_android_ndk//:BUILD.ndk_sysroot.tpl`. Everything else in the template
   is byte-for-byte the upstream behavior.

2. **`ndk/BUILD.androidndk.bazel`** - `exports_files(["source.properties"])` so a
   consumer can `rctx.path(Label("@androidndk_<host>//:source.properties")).dirname`
   to locate the NDK root and derive the sysroot directory.

No change to the cc-toolchain path or any existing target; this is strictly
additive. Validated by building the `basic_app` example (the sysroot template is
rendered and consumed by the registered cc toolchain).

### Consumer sketch (rules_swift)

```starlark
# host-select the per-host repo at repo-rule time
ndk_root = rctx.path(Label("@androidndk_%s//:source.properties" % host)).dirname
sysroot  = "%s/toolchains/llvm/prebuilt/%s-x86_64/sysroot" % (ndk_root, host)
# swiftc -sdk <sysroot>; package .../sysroot:libcxx_shared_aarch64-linux-android
```
